### PR TITLE
[#5] ✨ Feat: MyReport 관련 엔티티 및 Enum 구현

### DIFF
--- a/src/main/java/com/example/speakOn/domain/myReport/entity/ConversationCorrection.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/entity/ConversationCorrection.java
@@ -1,0 +1,31 @@
+package com.example.speakOn.domain.myReport.entity;
+
+import com.example.speakOn.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "conversation_correction")
+public class ConversationCorrection extends BaseEntity {
+
+    // 리포트 (N:1, 필수)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "report_id", nullable = false)
+    private MyReport report;
+
+    // 원문 (User)
+    @Column(name = "original_content", columnDefinition = "TEXT", nullable = false)
+    private String originalContent;
+
+    // 교정문 (AI)
+    @Column(name = "corrected_content", columnDefinition = "TEXT", nullable = false)
+    private String correctedContent;
+
+    // 교정 이유
+    @Column(name = "correction_reason", columnDefinition = "TEXT")
+    private String correctionReason;
+}

--- a/src/main/java/com/example/speakOn/domain/myReport/entity/ConversationTone.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/entity/ConversationTone.java
@@ -1,0 +1,30 @@
+package com.example.speakOn.domain.myReport.entity;
+
+import com.example.speakOn.domain.myReport.enums.ToneType;
+import com.example.speakOn.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "conversation_tone")
+public class ConversationTone extends BaseEntity {
+
+    // 리포트 (1:1, 필수)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "report_id", nullable = false, unique = true)
+    private MyReport report;
+
+    // 사용자 톤
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_tone", length = 20)
+    private ToneType userTone;
+
+    // 기대 톤
+    @Enumerated(EnumType.STRING)
+    @Column(name = "expected_tone", length = 20)
+    private ToneType expectedTone;
+}

--- a/src/main/java/com/example/speakOn/domain/myReport/entity/MyReport.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/entity/MyReport.java
@@ -1,0 +1,48 @@
+package com.example.speakOn.domain.myReport.entity;
+
+import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
+import com.example.speakOn.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "my_report")
+public class MyReport extends BaseEntity {
+
+    // 대화 세션 (1:1, 필수)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false, unique = true)
+    private ConversationSession session;
+
+    // 대화 톤 (1:1, 양방향)
+    @OneToOne(mappedBy = "report", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private ConversationTone conversationTone;
+
+    // 대화 교정 (1:N, 양방향)
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ConversationCorrection> corrections = new ArrayList<>();
+
+    // 사용자 소감
+    @Column(name = "user_reflection", length = 120)
+    private String userReflection;
+
+    // AI 요약
+    @Column(name = "ai_summary", columnDefinition = "TEXT")
+    private String aiSummary;
+
+    // AI 근거 설명 (JSONB)
+    @Column(name = "ai_reason", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Builder.Default
+    private List<String> aiReason = new ArrayList<>();
+}

--- a/src/main/java/com/example/speakOn/domain/myReport/enums/ToneType.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/enums/ToneType.java
@@ -1,0 +1,5 @@
+package com.example.speakOn.domain.myReport.enums;
+
+public enum ToneType {
+    CASUAL, NEUTRAL, PROFESSIONAL
+}


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: MyReport 도메인 핵심 엔티티 구현 -->

## #️⃣ 연관된 이슈
> - #5

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

**MyReport 엔티티** `(domain/myReport/entity/MyReport)`

- 대화 세션 종료 후 생성되는 리포트 데이터

> 1. **session_id**  : 리포트가 생성된 대화 세션 ID
> 2. **user_reflection**  : 사용자가 작성한 대화 소감
> 3. **ai_summary** : AI가 생성한 대화 요약
> 4. **ai_reason** : AI 요약 및 피드백 근거 (JSONB)

---

**ConversationTone 엔티티** `(domain/myReport/entity/ConversationTone)`
- 대화 톤 분석 결과 저장

> 1. **report_id** : 톤 분석 대상 리포트 ID (1:1)
> 2. **user_tone** : 분석된 사용자 대화 톤
> 3. **expected_tone** : AI가 제안하는 기대 톤

---

**ConversationCorrection 엔티티** `(domain/myReport/entity/ConversationCorrection)`
- AI 문장 교정 결과 저장

> 1. **report_id** : 교정 결과가 귀속되는 리포트 ID
> 2. **original_content** : 사용자 원문
> 3. **corrected_content** : AI 교정 문장
> 4. **correction_reason** : 교정 사유

---

**Enums**

> 1. **ToneType** : 대화 톤 구분 (`CASUAL`, `NEUTRAL`, `PROFESSIONAL`)
---

## 📌 공유 사항
<!-- 팀원들에게 공유해야 할 사항이 있다면 작성해주세요 -->

- **엔티티 매핑**
  ```java
  MyReport -> ConversationSession          // 1:1 단방향
  MyReport <-> ConversationTone            // 1:1 양방향 + Cascade
  MyReport <-> ConversationCorrection      // 1:N 양방향 + Cascade

- **1:1 관계 DB 제약 (1개의 리포트에는 하나의 톤 분석만 존재하도록 제한)**
  ```java
  @JoinColumn(unique = true) // ConversationTone

- **JSONB 사용**
   ```java
  List<String> aiReason
  ```
  - `aiReason` 필드는 단순 문자열 리스트 성격의 데이터이므로 조인 없이 조회 가능하도록 설계

---

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

---

## 📷 스크린샷
> ERD
<img width="1223" height="286" alt="image" src="https://github.com/user-attachments/assets/103597ac-2fe0-4128-9b8e-c8c97c081fec" />
<img width="1010" height="737" alt="image" src="https://github.com/user-attachments/assets/6764dc42-8dc2-47e0-9369-09258ed42f42" />

---

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

**엔티티 매핑 관련 의견을 부탁드립니다.**

> 1. `ConversationTone` -> `report_id` 
> `@JoinColumn(unique = true)`를 사용하여 **1:1 관계를 DB 수준에서 강제**했는데
    이 방식이 적합한지 의견 부탁드립니다.
> 2. `ConversationTone`, `ConversationCorrection `을 **양방향 매핑**으로 했는데
> 조회 및 관리 측면에서 단방향으로 단순화하는 것이 더 나을지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 대화 수정 및 피드백 추적 기능 추가
  * 사용자 톤(말투) 분석 및 평가 기능 추가
  * 대화 세션 기반 보고서 생성 기능 추가
  * 음성 학습 분석 보고서에 AI 요약 및 개선 이유 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->