### PR TITLE
[#36] ✨[Feat]: 세션 종료 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,34 +25,34 @@ repositories {
 }
 
 dependencies {
-	// Spring Data JPA
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Spring Data JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// Spring Security
+    // Spring Security
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 //	testImplementation 'org.springframework.security:spring-security-test'
 
-	// Jwt
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
-	implementation 'org.springframework.boot:spring-boot-configuration-processor'
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'org.springframework.boot:spring-boot-configuration-processor'
 
-	// Spring Web
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    // Spring Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok' // Lombok 어노테이션 컴파일 시 처리
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok' // Lombok 어노테이션 컴파일 시 처리
 
-	// PostgreSQL
-	runtimeOnly 'org.postgresql:postgresql'
+    // PostgreSQL
+    runtimeOnly 'org.postgresql:postgresql'
 
-	// SpringDoc (OpenAPI/Swagger for Spring Boot 3.x)
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    // SpringDoc (OpenAPI/Swagger for Spring Boot 3.x)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
-	// Test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //Google TTS, STT
@@ -61,6 +61,9 @@ dependencies {
 
     //AWS S3
     implementation 'software.amazon.awssdk:s3:2.25.0'
+
+    //검증
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/speakOn/domain/mySpeak/controller/MySpeakController.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/controller/MySpeakController.java
@@ -1,9 +1,11 @@
 package com.example.speakOn.domain.mySpeak.controller;
 
 import com.example.speakOn.domain.mySpeak.docs.MySpeakControllerDocs;
+import com.example.speakOn.domain.mySpeak.dto.request.CompleteSessionRequest;
 import com.example.speakOn.domain.mySpeak.dto.request.CreateSessionRequest;
 import com.example.speakOn.domain.mySpeak.dto.request.SttRequestDto;
 import com.example.speakOn.domain.mySpeak.dto.request.TtsRequestDto;
+import com.example.speakOn.domain.mySpeak.dto.response.CompleteSessionResponse;
 import com.example.speakOn.domain.mySpeak.dto.response.SttResponseDto;
 import com.example.speakOn.domain.mySpeak.dto.response.TtsResponseDto;
 import com.example.speakOn.domain.mySpeak.dto.response.WaitScreenResponse;
@@ -64,5 +66,16 @@ public class MySpeakController implements MySpeakControllerDocs {
         String base64 = Base64.getEncoder().encodeToString(audioBytes);
 
         return ApiResponse.onSuccess(new TtsResponseDto(base64));
+    }
+
+    // 세션 종료 api
+    @PostMapping("/{sessionId}/complete")
+    public ApiResponse<CompleteSessionResponse> completeSession(
+            @PathVariable Long sessionId,
+            @Valid @RequestBody CompleteSessionRequest request) {
+
+        CompleteSessionResponse response = mySpeakService.completeSession(sessionId, request);
+
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
@@ -163,11 +163,11 @@ public interface MySpeakControllerDocs {
             
             ### 📌 발생 가능한 에러
             
-            - ❌ **400**\s
+            - ❌ **400**
              - **@NotNull 위반**: `endedAt` 또는 `totalTime` 누락
             - ❌ **404**
              - **MS4005**: 존재하지 않는 세션 ID
-            - ❌ **500** \s
+            - ❌ **500** 
              - **MS5007**: 마무리 TTS 생성 실패 (음성 합성 오류)
             """
     ) ApiResponse<CompleteSessionResponse> completeSession(@PathVariable Long sessionId, @RequestBody CompleteSessionRequest request);

--- a/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
@@ -1,8 +1,10 @@
 package com.example.speakOn.domain.mySpeak.docs;
 
+import com.example.speakOn.domain.mySpeak.dto.request.CompleteSessionRequest;
 import com.example.speakOn.domain.mySpeak.dto.request.CreateSessionRequest;
 import com.example.speakOn.domain.mySpeak.dto.request.SttRequestDto;
 import com.example.speakOn.domain.mySpeak.dto.request.TtsRequestDto;
+import com.example.speakOn.domain.mySpeak.dto.response.CompleteSessionResponse;
 import com.example.speakOn.domain.mySpeak.dto.response.SttResponseDto;
 import com.example.speakOn.domain.mySpeak.dto.response.TtsResponseDto;
 import com.example.speakOn.domain.mySpeak.dto.response.WaitScreenResponse;
@@ -12,6 +14,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -135,6 +138,39 @@ public interface MySpeakControllerDocs {
                     """
     )
     ApiResponse<TtsResponseDto> tts(@RequestBody TtsRequestDto request);
+
+
+    @Operation(
+            summary = "세션 종료 처리",
+            description = """
+            대화 세션을 종료하고 **마무리 TTS를 생성**합니다.
+            
+            **15분 자동 종료, 사용자 종료 버튼, 질문 완료** 3가지 시나리오 모두 처리.
+            
+            **종료 성공 시**:
+            - 마무리 멘트 TTS를 **base64 문자열**로 즉시 반환
+            - **사용자 문장수 자동 계산** 및 세션 완료 상태 저장  
+            
+            ### 📥 요청 데이터
+            | 필드 | 타입 | 필수 | 설명 |
+            |------|------|------|------|
+            | `endedAt` | `LocalDateTime` | ✅ | 종료 시점 (현재 종료 시간) |
+            | `totalTime` | `Integer` | ✅ | 총 대화 시간 (초 단위, 일시정지 제외) |
+            
+            ### 📤 응답
+            - **성공**: 마무리 TTS base64 + 통계 정보 반환
+            - **실패**: 에러 코드 반환
+            
+            ### 📌 발생 가능한 에러
+            
+            - ❌ **400**\s
+             - **@NotNull 위반**: `endedAt` 또는 `totalTime` 누락
+            - ❌ **404**
+             - **MS4005**: 존재하지 않는 세션 ID
+            - ❌ **500** \s
+             - **MS5007**: 마무리 TTS 생성 실패 (음성 합성 오류)
+            """
+    ) ApiResponse<CompleteSessionResponse> completeSession(@PathVariable Long sessionId, @RequestBody CompleteSessionRequest request);
 
 
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/dto/request/CompleteSessionRequest.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/dto/request/CompleteSessionRequest.java
@@ -1,0 +1,17 @@
+package com.example.speakOn.domain.mySpeak.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CompleteSessionRequest {
+    @NotNull
+    private LocalDateTime endedAt;       // 현재 시간
+
+    @NotNull
+    private Integer totalTime;           // 실제 대화 시간 (일시정지 제외)
+}

--- a/src/main/java/com/example/speakOn/domain/mySpeak/dto/request/TtsRequestDto.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/dto/request/TtsRequestDto.java
@@ -2,12 +2,8 @@ package com.example.speakOn.domain.mySpeak.dto.request;
 
 import com.example.speakOn.domain.mySpeak.enums.MessageType;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
@@ -24,4 +20,6 @@ public class TtsRequestDto {
 
     @NotNull
     private Long sessionId;
+
+
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/dto/response/CompleteSessionResponse.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/dto/response/CompleteSessionResponse.java
@@ -1,0 +1,16 @@
+package com.example.speakOn.domain.mySpeak.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CompleteSessionResponse {
+
+    private Long sessionId;
+    private Integer totalTime; // 총 시간
+    private Integer sentenceCount; //문장 수
+    private String closingTtsBase64; // tts 로 변환된 마무리 멘트
+}

--- a/src/main/java/com/example/speakOn/domain/mySpeak/entity/ConversationSession.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/entity/ConversationSession.java
@@ -55,11 +55,10 @@ public class ConversationSession extends BaseEntity {
     }
 
     // 대화 종료 시 결과 데이터 업데이트
-    public void completeSession(Integer totalTime, Integer sentenceCount, Integer difficulty) {
+    public void completeSession(Integer totalTime, Integer sentenceCount, LocalDateTime endedAt) {
         this.status = SessionStatus.COMPLETED;
         this.totalTime = totalTime;
         this.sentenceCount = sentenceCount;
-        this.userDifficulty = difficulty;
-        this.endedAt = LocalDateTime.now();
+        this.endedAt = endedAt;
     }
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/repository/ConversationMessageRepository.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/repository/ConversationMessageRepository.java
@@ -1,9 +1,12 @@
 package com.example.speakOn.domain.mySpeak.repository;
 
 import com.example.speakOn.domain.mySpeak.entity.ConversationMessage;
+import com.example.speakOn.domain.mySpeak.enums.SenderRole;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,5 +20,15 @@ public class ConversationMessageRepository {
 
     public ConversationMessage findById(Long messageId) {
         return em.find(ConversationMessage.class, messageId);
+    }
+
+    public List<ConversationMessage> findBySessionIdAndSenderRole(Long sessionId, SenderRole senderRole) {
+        return em.createQuery("select m from ConversationMessage m " +
+                        "join fetch m.session " +
+                        "where m.session.id = :sessionId and m.senderRole = :senderRole " +
+                        "ORDER BY m.createdAt ASC")
+                .setParameter("sessionId", sessionId)
+                .setParameter("senderRole", senderRole)
+                .getResultList();
     }
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/service/S3UploaderService.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/service/S3UploaderService.java
@@ -45,7 +45,7 @@ public class S3UploaderService {
             return url;
 
         } catch (S3Exception e) {
-            log.error("S3 서비스 오류 - Bucket: {}, Key: {}", s3BucketName, e.awsErrorDetails().errorCode(), e);
+            log.error("S3 서비스 오류 - Bucket: {}, errorCode: {}", s3BucketName, e.awsErrorDetails().errorCode(), e);
             throw new MySpeakException(MySpeakErrorCode.S3_BUCKET_ACCESS_DENIED);
 
         } catch (SdkClientException e) {


### PR DESCRIPTION


## #️⃣ 연관된 이슈
✨[Feat]: 세션 종료 API 구현 #36

## 📝 작업 내용
-  세션 종료 API `/api/v1/my-speak/sessions/{sessionId}/complete` POST 구현
-  `CompleteSessionRequest` DTO 생성 (`endedAt`, `totalTime` 필수 검증)
-  세션 상태 → `COMPLETED` 변경
-  `totalTime` 누적 저장 (일시정지 제외 실시간)
-  GlobalExceptionHandler로 `@Valid` 예외 통합 처리
-  Swagger 테스트: 필드 누락/빈값/null 전부 **400 Bad Request** 검증 완료! 



## 📌 공유 사항
-  검증 implementation 'org.springframework.boot:spring-boot-starter-validation' 추가 (build.grandle)

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1588" height="629" alt="image" src="https://github.com/user-attachments/assets/a3d9d26b-ca83-408f-8f7a-aa9f26d3e9ba" />
<img width="863" height="174" alt="image" src="https://github.com/user-attachments/assets/8a883485-47e1-4e04-ab19-2f56888d6154" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 음성-텍스트 변환(STT) 기능 추가
  * 텍스트-음성 변환(TTS) 기능 추가
  * 세션 완료 및 종료 기능 추가
  * 대화 세션 메시지 저장소 및 조회 기능 추가

* **Bug Fixes**
  * 저장소 호출명 오류 수정

* **Chores**
  * Google Cloud Speech/Text-to-Speech 및 AWS S3 SDK 의존성 추가
  * Spring Boot validation 의존성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->