### PR TITLE
[#45]✨ Feat: My Role 추가 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ src/main/generated/
 # FFmpeg binary
 ffmpeg-bin/
 ffmpeg.zip
+
+#env
+.env

--- a/src/main/java/com/example/speakOn/domain/avatar/repository/AvatarRepository.java
+++ b/src/main/java/com/example/speakOn/domain/avatar/repository/AvatarRepository.java
@@ -1,0 +1,7 @@
+package com.example.speakOn.domain.avatar.repository;
+
+import com.example.speakOn.domain.avatar.entity.Avatar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AvatarRepository extends JpaRepository<Avatar, Long> {
+}

--- a/src/main/java/com/example/speakOn/domain/myRole/controller/MyRoleController.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/controller/MyRoleController.java
@@ -1,0 +1,57 @@
+package com.example.speakOn.domain.myRole.controller;
+
+import com.example.speakOn.domain.myRole.dto.MyRoleRequest;
+import com.example.speakOn.domain.myRole.dto.MyRoleResponse;
+import com.example.speakOn.domain.myRole.service.MyRoleServiceImpl;
+import com.example.speakOn.global.apiPayload.ApiResponse;
+import com.example.speakOn.global.apiPayload.code.status.ErrorStatus;
+import com.example.speakOn.global.util.AuthUtil;
+import com.example.speakOn.global.validation.annotation.ApiErrorCodeExample;
+import com.example.speakOn.global.validation.annotation.ApiErrorCodeExamples;
+import com.example.speakOn.global.validation.annotation.ApiSuccessCodeExample;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "My Role API", description = "마이롤 관련 API")
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/my-role")
+public class MyRoleController {
+
+    private final MyRoleServiceImpl myRoleService;
+    private final AuthUtil authUtil;
+
+    @Operation(
+            summary = "롤 추가 API",
+            description = "사람(아바타), 직무, 상황을 선택하여 새로운 롤을 추가합니다." +
+                    "중복된 아바타 + 직무 + 상황 조합은 'MY_ROLE_ALREADY_EXISTS'를 반환합니다."
+    )
+    @ApiSuccessCodeExample(resultClass = MyRoleResponse.CreateMyRoleResultDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "AVATAR_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "MY_ROLE_ALREADY_EXISTS"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @PostMapping
+    public ApiResponse<MyRoleResponse.CreateMyRoleResultDTO> createMyRole(
+            @Valid @RequestBody MyRoleRequest.CreateMyRoleDTO request) {
+
+        Long userId = authUtil.getCurrentUserId();
+
+        MyRoleResponse.CreateMyRoleResultDTO response = myRoleService.createMyRole(userId, request);
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/myRole/converter/MyRoleConverter.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/converter/MyRoleConverter.java
@@ -1,0 +1,17 @@
+package com.example.speakOn.domain.myRole.converter;
+
+import com.example.speakOn.domain.myRole.dto.MyRoleResponse;
+import com.example.speakOn.domain.myRole.entity.MyRole;
+
+public class MyRoleConverter {
+
+    public static MyRoleResponse.CreateMyRoleResultDTO toCreateMyRoleResultDTO(MyRole myRole) {
+        return MyRoleResponse.CreateMyRoleResultDTO.builder()
+                .myRoleId(myRole.getId())
+                .avatarId(myRole.getAvatar().getId())
+                .avatarName(myRole.getAvatar().getName())
+                .job(myRole.getJob())
+                .situation(myRole.getSituation())
+                .build();
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/myRole/dto/MyRoleRequest.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/dto/MyRoleRequest.java
@@ -1,0 +1,31 @@
+package com.example.speakOn.domain.myRole.dto;
+
+import com.example.speakOn.domain.avatar.enums.SituationType;
+import com.example.speakOn.domain.myRole.enums.JobType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MyRoleRequest {
+
+    @Schema(description = "롤 추가 요청 DTO")
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateMyRoleDTO {
+
+        @Schema(description = "선택한 아바타 ID", example = "1")
+        @NotNull(message = "avatarId는 필수입니다.")
+        private Long avatarId;
+
+        @Schema(description = "선택한 직무 (MARKETING, DEVELOPMENT, DESIGN, PLANNING, SALES, BUSINESS)", example = "MARKETING")
+        @NotNull(message = "직무(job)는 필수입니다.")
+        private JobType job;
+
+        @Schema(description = "선택한 상황 (INTERVIEW, MEETING, ONE_ON_ONE_MEETING, COFFEE_CHAT)", example = "INTERVIEW")
+        @NotNull(message = "상황(situation)은 필수입니다.")
+        private SituationType situation;
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/myRole/dto/MyRoleResponse.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/dto/MyRoleResponse.java
@@ -1,0 +1,35 @@
+package com.example.speakOn.domain.myRole.dto;
+
+import com.example.speakOn.domain.avatar.enums.SituationType;
+import com.example.speakOn.domain.myRole.enums.JobType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MyRoleResponse {
+
+    @Schema(description = "롤 추가 응답 DTO")
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateMyRoleResultDTO {
+
+        @Schema(description = "생성된 MyRole ID", example = "1")
+        private Long myRoleId;
+
+        @Schema(description = "선택한 아바타 ID", example = "1")
+        private Long avatarId;
+
+        @Schema(description = "아바타 이름", example = "Emily")
+        private String avatarName;
+
+        @Schema(description = "선택한 직무", example = "MARKETING")
+        private JobType job;
+
+        @Schema(description = "선택한 상황", example = "INTERVIEW")
+        private SituationType situation;
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
@@ -1,21 +1,18 @@
 package com.example.speakOn.domain.myRole.repository;
 
+import com.example.speakOn.domain.avatar.entity.Avatar;
+import com.example.speakOn.domain.avatar.enums.SituationType;
 import com.example.speakOn.domain.myRole.entity.MyRole;
-import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Repository;
+import com.example.speakOn.domain.myRole.enums.JobType;
+import com.example.speakOn.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@Repository
-@Slf4j
-@RequiredArgsConstructor
-public class MyRoleRepository {
+import java.util.Optional;
 
-    private final EntityManager em;
+public interface MyRoleRepository extends JpaRepository<MyRole, Long>, MyRoleRepositoryCustom {
 
-    //대화 세션 생성하는데 필요해서 생성
-    public MyRole findById(Long myRoleId) {
-        return em.find(MyRole.class, myRoleId);
-    }
+    boolean existsByUserAndAvatarAndJobAndSituation(User user, Avatar avatar, JobType job, SituationType situation);
+
+    Optional<MyRole> findByIdAndUser(Long id, User user);
+
 }

--- a/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepositoryCustom.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.speakOn.domain.myRole.repository;
+
+import com.example.speakOn.domain.myRole.entity.MyRole;
+
+public interface MyRoleRepositoryCustom {
+
+    MyRole findMyRoleById(Long myRoleId);
+
+}

--- a/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepositoryImpl.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.example.speakOn.domain.myRole.repository;
+
+import com.example.speakOn.domain.myRole.entity.MyRole;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MyRoleRepositoryImpl implements MyRoleRepositoryCustom {
+
+    private final EntityManager em;
+
+    //대화 세션 생성하는데 필요해서 생성
+    @Override
+    public MyRole findMyRoleById(Long myRoleId) {
+        return em.find(MyRole.class, myRoleId);
+    }
+
+}

--- a/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleService.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleService.java
@@ -1,0 +1,11 @@
+package com.example.speakOn.domain.myRole.service;
+
+import com.example.speakOn.domain.myRole.dto.MyRoleRequest;
+import com.example.speakOn.domain.myRole.dto.MyRoleResponse;
+
+public interface MyRoleService {
+
+    MyRoleResponse.CreateMyRoleResultDTO createMyRole(Long userId, MyRoleRequest.CreateMyRoleDTO request);
+
+
+}

--- a/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
@@ -1,0 +1,68 @@
+package com.example.speakOn.domain.myRole.service;
+
+import com.example.speakOn.domain.avatar.entity.Avatar;
+import com.example.speakOn.domain.avatar.repository.AvatarRepository;
+import com.example.speakOn.domain.myRole.converter.MyRoleConverter;
+import com.example.speakOn.domain.myRole.dto.MyRoleRequest;
+import com.example.speakOn.domain.myRole.dto.MyRoleResponse;
+import com.example.speakOn.domain.myRole.entity.MyRole;
+import com.example.speakOn.domain.myRole.repository.MyRoleRepository;
+import com.example.speakOn.domain.user.entity.User;
+import com.example.speakOn.domain.user.repository.UserRepository;
+import com.example.speakOn.global.apiPayload.code.status.ErrorStatus;
+import com.example.speakOn.global.apiPayload.exception.handler.ErrorHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyRoleServiceImpl implements MyRoleService {
+
+    private final MyRoleRepository myRoleRepository;
+    private final AvatarRepository avatarRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 롤 추가 (사람/직무/상황 선택)
+     *
+     * @param userId  현재 로그인한 사용자 ID
+     * @param request 롤 추가 요청 DTO (avatarId, job, situation)
+     * @return 생성된 MyRole 정보
+     */
+    @Transactional
+    @Override
+    public MyRoleResponse.CreateMyRoleResultDTO createMyRole(Long userId, MyRoleRequest.CreateMyRoleDTO request) {
+
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 아바타 조회
+        Avatar avatar = avatarRepository.findById(request.getAvatarId())
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.AVATAR_NOT_FOUND));
+
+        // 3. 중복 체크 (같은 user, avatar, job, situation 조합이 이미 존재하는지)
+        boolean exists = myRoleRepository.existsByUserAndAvatarAndJobAndSituation(
+                user, avatar, request.getJob(), request.getSituation());
+        if (exists) {
+            throw new ErrorHandler(ErrorStatus.MY_ROLE_ALREADY_EXISTS);
+        }
+
+        // 4. MyRole 생성 및 저장
+        MyRole myRole = MyRole.builder()
+                .user(user)
+                .avatar(avatar)
+                .job(request.getJob())
+                .situation(request.getSituation())
+                .build();
+
+        MyRole savedMyRole = myRoleRepository.save(myRole);
+
+        // 5. 응답 변환
+        return MyRoleConverter.toCreateMyRoleResultDTO(savedMyRole);
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/mySpeak/service/MySpeakService.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/service/MySpeakService.java
@@ -1,7 +1,7 @@
 package com.example.speakOn.domain.mySpeak.service;
 
 import com.example.speakOn.domain.myRole.entity.MyRole;
-import com.example.speakOn.domain.myRole.repository.MyRoleRepository;
+import com.example.speakOn.domain.myRole.repository.MyRoleRepositoryImpl;
 import com.example.speakOn.domain.mySpeak.converter.MySpeakConverter;
 import com.example.speakOn.domain.mySpeak.dto.form.WaitScreenForm;
 import com.example.speakOn.domain.mySpeak.dto.request.CompleteSessionRequest;
@@ -28,11 +28,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -44,7 +42,7 @@ public class MySpeakService {
     private final TextSynthesisService textSynthesisService;
     private final MySpeakRepository mySpeakRepository;
     private final ConversationSessionRepository conversationSessionRepository;
-    private final MyRoleRepository myRoleRepository;
+    private final MyRoleRepositoryImpl myRoleRepositoryImpl;
     private final ConversationMessageRepository conversationMessageRepository;
     private final MySpeakConverter mySpeakConverter;
     private final S3UploaderService s3UploaderService;
@@ -96,7 +94,7 @@ public class MySpeakService {
     public Long createSession(CreateSessionRequest request) {
         try {
             // MyRole 조회
-            MyRole myRole = myRoleRepository.findById(request.getMyRoleId());
+            MyRole myRole = myRoleRepositoryImpl.findMyRoleById(request.getMyRoleId());
             if (myRole == null) {
                 log.warn("MyRole not found - myRoleId: {}", request.getMyRoleId());
                 throw new MySpeakException(MySpeakErrorCode.NO_MYROLES_AVAILABLE);

--- a/src/main/java/com/example/speakOn/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/speakOn/domain/user/controller/UserController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "유저 관련 페이지", description = "유저에 관한 API")
+@Tag(name = "User API", description = "유저에 관한 API")
 @Slf4j
 @Validated
 @RequiredArgsConstructor

--- a/src/main/java/com/example/speakOn/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/speakOn/global/apiPayload/code/status/ErrorStatus.java
@@ -22,7 +22,11 @@ public enum ErrorStatus implements BaseCode {
     KAKAO_USER_INFO_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500", "카카오 사용자 정보 조회에 실패했습니다."),
 
     // 유저 관련 에러
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER401", "아이디와 일치하는 사용자가 없습니다.");
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER401", "아이디와 일치하는 사용자가 없습니다."),
+
+    // MyRole 관련 에러
+    AVATAR_NOT_FOUND(HttpStatus.NOT_FOUND, "ROLE404", "존재하지 않는 아바타입니다."),
+    MY_ROLE_ALREADY_EXISTS(HttpStatus.CONFLICT, "ROLE409", "이미 동일한 역할이 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #45 
## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
#### My Role 추가 API 구현
- 엔드포인트 : `POST /api/my-role`
- 아바타 + 직무 + 상황 조합으로 새로운 MyRole 생성
- 중복 검증: 동일한 조합이 이미 존재하면 `MY_ROLE_ALREADY_EXISTS` 에러 반환
- 동시성 제어
  - 서비스 단에서 중복 조합 검증 ->`MY_ROLE_ALREADY_EXISTS`
  - DB단에서 `user_id, avatar_id, job, situation` 조합에 유니크 제약 조건 적용

#### MyRoleRepository를 Custom Repository 패턴을 적용
- MyRoleRepository를 인터페이스로 변환
- EntityManager를 직접 사용하는 로직 분리를 위해 Custom 인터페이스, 구현체 추가
- Spring Data JPA의 쿼리 메서드와 EntityManager 방식을 동시에 사용할 수 있도록 구조 개선
- jpa 기본 메서드와 겹쳐 custom 메서드명을 findById에서 findMyRoleById로 변경

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
- 현재 팀원마다 다르게 Spring Data JPA 방식과 EntityManager 방식을 모두 사용하고 있는 상태입니다.
그러면 `JpaRepository` 상속 시 충돌이 발생해서, 두 방식을 모두 사용하기 위해 **Custom Repository(인터페이스+구현체)** 구조로 리팩토링했습니다.

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="487" height="272" alt="image" src="https://github.com/user-attachments/assets/d2e760d3-15d4-457b-b6a2-f90e6c6e80f0" />

<img width="487" height="272" alt="image" src="https://github.com/user-attachments/assets/60750e2a-803b-4458-8d67-4f79382c771e" />

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 아바타를 선택하여 새로운 역할을 생성할 수 있습니다.
  * 역할 생성 시 직업과 상황 정보를 지정할 수 있습니다.
  * 중복된 역할 생성을 자동으로 방지합니다.

* **개선사항**
  * API 문서 라벨 업데이트
  * 환경 설정 파일 보안 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->