### PR TITLE
[#67] ✨ Feat: 대화 한턴 보장하는 API

### DIFF
--- a/src/main/java/com/example/speakOn/domain/avatar/enums/CadenceType.java
+++ b/src/main/java/com/example/speakOn/domain/avatar/enums/CadenceType.java
@@ -1,5 +1,19 @@
 package com.example.speakOn.domain.avatar.enums;
 
 public enum CadenceType {
-    SHORT, MEDIUM, LONG
+
+    SHORT(1.15), //빠르게
+    MEDIUM(1.0), //보통
+    LONG(0.85);  //느리게
+
+    private final double speedRate;
+
+    CadenceType(double speedRate) {
+        this.speedRate = speedRate;
+    }
+
+    public double getSpeedRate() {
+        return speedRate;
+    }
 }
+

--- a/src/main/java/com/example/speakOn/domain/mySpeak/controller/MySpeakController.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/controller/MySpeakController.java
@@ -5,6 +5,7 @@ import com.example.speakOn.domain.mySpeak.dto.request.*;
 
 import com.example.speakOn.domain.mySpeak.dto.response.*;
 
+import com.example.speakOn.domain.mySpeak.enums.MessageType;
 import com.example.speakOn.domain.mySpeak.service.MySpeakService;
 import com.example.speakOn.global.apiPayload.ApiResponse;
 import com.example.speakOn.global.util.AuthUtil;
@@ -88,14 +89,18 @@ public class MySpeakController implements MySpeakControllerDocs {
         return ApiResponse.onSuccess(null);
     }
 
-    //대화 한턴을 보장하는 api
-    @PostMapping("/sessions/{sessionId}/turns")
+    @PostMapping(value = "/sessions/{sessionId}/turns",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<ConversationTurnResponse> handleTurn(
             @PathVariable Long sessionId,
             @RequestPart("file") MultipartFile file,
-            @Valid @RequestPart("request") ConversationTurnRequest request) {
-
+            @RequestParam(defaultValue = "en-US") String languageCode,  // ← @RequestParam!
+            @RequestParam(defaultValue = "MAIN") MessageType messageType  // ← @RequestParam!
+    ) {
+        // 서비스에서 ConversationTurnRequest 생성
+        ConversationTurnRequest request = new ConversationTurnRequest(languageCode, messageType);
         ConversationTurnResponse response = mySpeakService.handelTurn(file, sessionId, request);
         return ApiResponse.onSuccess(response);
     }
+
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/controller/MySpeakController.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/controller/MySpeakController.java
@@ -3,11 +3,8 @@ package com.example.speakOn.domain.mySpeak.controller;
 import com.example.speakOn.domain.mySpeak.docs.MySpeakControllerDocs;
 import com.example.speakOn.domain.mySpeak.dto.request.*;
 
-import com.example.speakOn.domain.mySpeak.dto.response.CompleteSessionResponse;
+import com.example.speakOn.domain.mySpeak.dto.response.*;
 
-import com.example.speakOn.domain.mySpeak.dto.response.SttResponseDto;
-import com.example.speakOn.domain.mySpeak.dto.response.TtsResponseDto;
-import com.example.speakOn.domain.mySpeak.dto.response.WaitScreenResponse;
 import com.example.speakOn.domain.mySpeak.service.MySpeakService;
 import com.example.speakOn.global.apiPayload.ApiResponse;
 import com.example.speakOn.global.util.AuthUtil;
@@ -89,5 +86,16 @@ public class MySpeakController implements MySpeakControllerDocs {
 
         mySpeakService.saveUserDifficulty(sessionId, request);
         return ApiResponse.onSuccess(null);
+    }
+
+    //대화 한턴을 보장하는 api
+    @PostMapping("/sessions/{sessionId}/turns")
+    public ApiResponse<ConversationTurnResponse> handleTurn(
+            @PathVariable Long sessionId,
+            @RequestPart("file") MultipartFile file,
+            @Valid @RequestPart("request") ConversationTurnRequest request) {
+
+        ConversationTurnResponse response = mySpeakService.handelTurn(file, sessionId, request);
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/controller/SttTestController.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/controller/SttTestController.java
@@ -24,7 +24,7 @@ public class SttTestController {
     @Operation(summary = "🔥 STT 테스트 - 파일만 업로드")
     public ApiResponse<SttResponseDto> sttSimpleTest(
             @RequestPart("file") MultipartFile file,
-            @RequestParam(defaultValue = "ko-KR") String languageCode,
+            @RequestParam(defaultValue = "en-US") String languageCode,
             @RequestParam(defaultValue = "MAIN") MessageType messageType,
             @RequestParam(defaultValue = "1") Long sessionId
     ) {

--- a/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
@@ -2,13 +2,11 @@ package com.example.speakOn.domain.mySpeak.docs;
 
 import com.example.speakOn.domain.mySpeak.dto.request.*;
 
-import com.example.speakOn.domain.mySpeak.dto.response.CompleteSessionResponse;
+import com.example.speakOn.domain.mySpeak.dto.response.*;
 
-import com.example.speakOn.domain.mySpeak.dto.response.SttResponseDto;
-import com.example.speakOn.domain.mySpeak.dto.response.TtsResponseDto;
-import com.example.speakOn.domain.mySpeak.dto.response.WaitScreenResponse;
 import com.example.speakOn.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -205,4 +203,69 @@ public interface MySpeakControllerDocs {
                     """
     )
     public ApiResponse<Void> saveUserDifficulty(@PathVariable Long sessionId, @Valid @RequestBody UserDifficultyRequest request);
+
+
+    @Operation(
+            summary = "대화 한 턴 처리",
+            description = """
+                    사용자가 녹음한 **음성 파일을 입력으로 받아**
+                    한 턴의 대화를 **원자적으로 처리**합니다.
+                    
+                    처리 흐름:
+                    1. 사용자 음성 STT 변환
+                    2. USER 메시지 저장
+                    3. AI 질문 생성
+                    4. AI 질문을 TTS로 변환
+                    5. AI 메시지 저장
+                    6. AI 메시지 저장 후 음성 응답 반환
+                    
+                    ### 📥 요청 데이터 (multipart/form-data)
+                    
+                    | 필드 | 타입 | 필수 | 설명 |
+                    |------|------|------|------|
+                    | `file` | File | ✅ | 사용자 음성 파일 |
+                    | `request` | Object | ✅ | 대화 턴 메타 정보 |
+                    
+                    #### request(JSON)
+                    | 필드 | 타입 | 필수 | 설명 |
+                    |------|------|------|------|
+                    | `languageCode` | String | ❌ | 음성 언어 코드 (기본값: en-US) |
+                    | `messageType` | String | ✅ | 메시지 타입 (MAIN, FOLLOW, CLOSING) |
+                    
+                    > ⚠️ 음성 파일은 반드시 `multipart/form-data` 형식으로 전송해야 합니다.
+                    
+                    ---
+                    
+                    ### 📤 응답 데이터
+                    
+                    | 필드 | 타입 | 설명 |
+                    |------|------|------|
+                    | `text` | String | AI가 생성한 질문 텍스트 |
+                    | `base64Audio` | String | base64 인코딩된 AI 음성(mp3) |
+                    | `messageType` | String | 대화 메시지 타입 |
+                    
+                    ---
+                    
+                    ### ❗ 발생 가능한 에러
+                    
+                    #### ❌ 400 Bad Request
+                    - 음성 파일 누락
+                    - request 데이터 누락 또는 형식 오류
+                    - 지원하지 않는 오디오 파일 형식 (MS4004)
+                    
+                    #### ❌ 404 Not Found
+                    - 존재하지 않는 세션 ID (MS4004)
+                    
+                    #### ❌ 500 Internal Server Error
+                    - STT 변환 실패 (MS5005)
+                    - TTS 변환 실패
+                    - AI 질문 생성 실패
+                    """
+    )
+    public ApiResponse<ConversationTurnResponse> handleTurn(
+            @Parameter(name = "sessionId", description = "세션 ID", required = true, example = "1")
+            @PathVariable("sessionId") Long sessionId,
+            @RequestPart("file") MultipartFile file,
+            @Valid @RequestPart("request") ConversationTurnRequest request);
+
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
@@ -4,6 +4,7 @@ import com.example.speakOn.domain.mySpeak.dto.request.*;
 
 import com.example.speakOn.domain.mySpeak.dto.response.*;
 
+import com.example.speakOn.domain.mySpeak.enums.MessageType;
 import com.example.speakOn.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,7 +14,9 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.web.bind.annotation.PathVariable;
+import io.swagger.v3.oas.annotations.media.Content;
 
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -262,10 +265,11 @@ public interface MySpeakControllerDocs {
                     - AI 질문 생성 실패
                     """
     )
-    public ApiResponse<ConversationTurnResponse> handleTurn(
-            @Parameter(name = "sessionId", description = "세션 ID", required = true, example = "1")
-            @PathVariable("sessionId") Long sessionId,
+    ApiResponse<ConversationTurnResponse> handleTurn(
+            @PathVariable Long sessionId,
             @RequestPart("file") MultipartFile file,
-            @Valid @RequestPart("request") ConversationTurnRequest request);
+            @RequestParam(defaultValue = "en-US") String languageCode,  // ← @RequestParam!
+            @RequestParam(defaultValue = "MAIN") MessageType messageType  // ← @RequestParam!
+    );
 
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/docs/MySpeakControllerDocs.java
@@ -228,14 +228,11 @@ public interface MySpeakControllerDocs {
                     |------|------|------|------|
                     | `file` | File | ✅ | 사용자 음성 파일 |
                     | `request` | Object | ✅ | 대화 턴 메타 정보 |
-                    
-                    #### request(JSON)
-                    | 필드 | 타입 | 필수 | 설명 |
-                    |------|------|------|------|
                     | `languageCode` | String | ❌ | 음성 언어 코드 (기본값: en-US) |
-                    | `messageType` | String | ✅ | 메시지 타입 (MAIN, FOLLOW, CLOSING) |
+                    | `messageType` | String | ❌ | 메시지 타입 (MAIN, FOLLOW, CLOSING) |
                     
                     > ⚠️ 음성 파일은 반드시 `multipart/form-data` 형식으로 전송해야 합니다.
+                    > languageCode, messageType 디폴트로 en-US, MAIN 이지만 messageType은 메인 질문 아니면 꼭 보내주세요!
                     
                     ---
                     

--- a/src/main/java/com/example/speakOn/domain/mySpeak/dto/request/ConversationTurnRequest.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/dto/request/ConversationTurnRequest.java
@@ -1,0 +1,19 @@
+package com.example.speakOn.domain.mySpeak.dto.request;
+
+import com.example.speakOn.domain.mySpeak.enums.MessageType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConversationTurnRequest {
+
+    private String languageCode = "en-US";
+
+    @NonNull
+    private MessageType messageType;
+}

--- a/src/main/java/com/example/speakOn/domain/mySpeak/dto/response/ConversationTurnResponse.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/dto/response/ConversationTurnResponse.java
@@ -1,0 +1,13 @@
+package com.example.speakOn.domain.mySpeak.dto.response;
+
+import com.example.speakOn.domain.mySpeak.enums.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ConversationTurnResponse {
+    private String questionText;
+    private String base64Audio;  // base64 인코딩된 mp3
+    private MessageType messageType;
+}

--- a/src/main/java/com/example/speakOn/domain/mySpeak/repository/MySpeakRepository.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/repository/MySpeakRepository.java
@@ -1,6 +1,8 @@
 package com.example.speakOn.domain.mySpeak.repository;
 
+import com.example.speakOn.domain.avatar.entity.Avatar;
 import com.example.speakOn.domain.myRole.entity.MyRole;
+import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
 import com.example.speakOn.domain.mySpeak.exception.MySpeakException;
 import com.example.speakOn.domain.mySpeak.exception.code.MySpeakErrorCode;
 import jakarta.persistence.EntityManager;
@@ -41,4 +43,15 @@ public class MySpeakRepository {
         }
 
     }
+
+    public ConversationSession findByIdWithAvatar(Long sessionId) {
+        return em.createQuery(
+                        "select s from ConversationSession s " +
+                                "join fetch s.myRole r " +
+                                "join fetch r.avatar a " +
+                                "where s.id = :sessionId ", ConversationSession.class)
+                .setParameter("sessionId", sessionId)
+                .getSingleResult();
+    }
+
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/service/ConversationTurnService.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/service/ConversationTurnService.java
@@ -1,0 +1,109 @@
+package com.example.speakOn.domain.mySpeak.service;
+
+import com.example.speakOn.domain.avatar.entity.Avatar;
+import com.example.speakOn.domain.mySpeak.entity.ConversationMessage;
+import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
+import com.example.speakOn.domain.mySpeak.enums.MessageType;
+import com.example.speakOn.domain.mySpeak.enums.SenderRole;
+import com.example.speakOn.domain.mySpeak.exception.MySpeakException;
+import com.example.speakOn.domain.mySpeak.exception.code.MySpeakErrorCode;
+import com.example.speakOn.domain.mySpeak.repository.ConversationMessageRepository;
+import com.example.speakOn.domain.mySpeak.repository.MySpeakRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ConversationTurnService {
+    private final S3UploaderService s3UploaderService;
+    private final ConversationMessageRepository conversationMessageRepository;
+    private final SpeechRecognitionService speechRecognitionService;
+    private final TextSynthesisService textSynthesisService;
+    private final MySpeakRepository mySpeakRepository;
+
+
+    // STT 공용로직
+    String sttAndSaveUserMessage(
+            MultipartFile audioFile,
+            ConversationSession session,
+            String languageCode,
+            MessageType messageType
+    ) {
+
+        validateAudioFile(audioFile);
+
+        //S3 업로드
+        String audioUrl = s3UploaderService.uploadAudio(audioFile, session.getId());
+
+        // STT 변환
+        String transcript = speechRecognitionService.recognizeFromFile(audioFile, languageCode);
+
+        // 사용자 메시지 저장
+        ConversationMessage userMessage = ConversationMessage.builder()
+                .session(session)
+                .senderRole(SenderRole.USER)
+                .content(transcript)
+                .audioUrl(audioUrl)
+                .messageType(messageType)
+                .build();
+
+        conversationMessageRepository.save(userMessage);
+
+        //질문 카운트 증가
+        if (messageType == MessageType.MAIN) {
+            session.incrementQuestionCount();
+        }
+
+        return transcript;
+    }
+
+    // TTS 공용로직
+    byte[] ttsAndSaveAiMessage(
+            ConversationSession session,
+            String text,
+            MessageType messageType,
+            String voicename,
+            Double speakingRate
+    ) {
+
+        //TTS 변환
+        byte[] audioBytes = textSynthesisService.synthesize(
+                text,
+                voicename,
+                speakingRate
+        );
+
+
+        //AI 메시지 저장
+        ConversationMessage aiMessage = ConversationMessage.builder()
+                .session(session)
+                .senderRole(SenderRole.AI)
+                .content(text)
+                .messageType(messageType)
+                .build();
+
+        conversationMessageRepository.save(aiMessage);
+
+        return audioBytes;
+    }
+
+    /**
+     * 업로드된 음성 파일 형식을 검증한다.
+     *
+     * @param file 업로드된 파일
+     * @throws MySpeakException 비어있거나 지원하지 않는 포맷일 경우
+     */
+    void validateAudioFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new MySpeakException(MySpeakErrorCode.INVALID_AUDIO_FORMAT);
+        }
+
+        String filename = file.getOriginalFilename();
+        if (filename == null || !filename.matches("(?i).*\\.(m4a|wav|mp3|mp4|webm|ogg|flac|aac)$")) {
+            throw new MySpeakException(MySpeakErrorCode.INVALID_AUDIO_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/mySpeak/service/MySpeakService.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/service/MySpeakService.java
@@ -188,7 +188,7 @@ public class MySpeakService {
     public CompleteSessionResponse completeSession(Long sessionId, CompleteSessionRequest request) {
 
         // 세션 조회
-        ConversationSession session = conversationSessionRepository.findById(sessionId);
+        ConversationSession session = mySpeakRepository.findByIdWithAvatar(sessionId);
         if (session == null) {
             throw new MySpeakException(MySpeakErrorCode.SESSION_NOT_FOUND);
         }
@@ -199,13 +199,15 @@ public class MySpeakService {
         // 세션 종료 업데이트 (TTS 전)
         session.completeSession(request.getTotalTime(), sentenceCount, request.getEndedAt());
 
+        Avatar avatar = session.getMyRole().getAvatar();
+
         // 마무리 멘트 TTS 생성 + DB 저장
         String closingText = "Thanks for sharing your perspective. I appreciate your time.";
         byte[] closingAudioBytes = generateSpeech(
                 new TtsRequestDto(
                         closingText,
-                        "en-US-Neural2-F",
-                        1.0,
+                        avatar.getTtsVoiceId(),
+                        avatar.getCadenceType().getSpeedRate(),
                         MessageType.CLOSING,
                         sessionId
                 )

--- a/src/main/java/com/example/speakOn/domain/mySpeak/service/MySpeakService.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/service/MySpeakService.java
@@ -1,11 +1,13 @@
 package com.example.speakOn.domain.mySpeak.service;
 
+import com.example.speakOn.domain.avatar.entity.Avatar;
 import com.example.speakOn.domain.myRole.entity.MyRole;
 import com.example.speakOn.domain.myRole.repository.MyRoleRepositoryImpl;
 import com.example.speakOn.domain.mySpeak.converter.MySpeakConverter;
 import com.example.speakOn.domain.mySpeak.dto.form.WaitScreenForm;
 import com.example.speakOn.domain.mySpeak.dto.request.*;
 import com.example.speakOn.domain.mySpeak.dto.response.CompleteSessionResponse;
+import com.example.speakOn.domain.mySpeak.dto.response.ConversationTurnResponse;
 import com.example.speakOn.domain.mySpeak.dto.response.SttResponseDto;
 import com.example.speakOn.domain.mySpeak.dto.response.WaitScreenResponse;
 import com.example.speakOn.domain.mySpeak.entity.ConversationMessage;
@@ -36,14 +38,13 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class MySpeakService {
 
-    private final SpeechRecognitionService speechRecognitionService;
-    private final TextSynthesisService textSynthesisService;
     private final MySpeakRepository mySpeakRepository;
     private final ConversationSessionRepository conversationSessionRepository;
     private final MyRoleRepositoryImpl myRoleRepositoryImpl;
     private final ConversationMessageRepository conversationMessageRepository;
     private final MySpeakConverter mySpeakConverter;
     private final S3UploaderService s3UploaderService;
+    private final ConversationTurnService conversationTurnService;
 
 
     /**
@@ -134,38 +135,19 @@ public class MySpeakService {
     public SttResponseDto recognizeSpeech(MultipartFile audioFile, SttRequestDto request) {
         log.info("MySpeak: STT 요청 처리 - sessionId={}", request.getSessionId());
 
-        validateAudioFile(audioFile);
-
         // 세션 조회
         ConversationSession session = conversationSessionRepository.findById(request.getSessionId());
         if (session == null) {
             throw new MySpeakException(MySpeakErrorCode.SESSION_NOT_FOUND);
         }
-
         log.info("session={}", session);
 
-        //S3 업로드
-        String audioUrl = s3UploaderService.uploadAudio(audioFile, request);
-
-        // STT 변환
-        String transcript = speechRecognitionService.recognizeFromFile(audioFile, request.getLanguageCode());
-
-        // 사용자 메시지 저장
-        ConversationMessage userMessage = ConversationMessage.builder()
-                .session(session)
-                .senderRole(SenderRole.USER)
-                .content(transcript)
-                .audioUrl(audioUrl)
-                .messageType(request.getMessageType())
-                .build();
-
-        conversationMessageRepository.save(userMessage);
-
-        //질문 카운트 증가
-        if (request.getMessageType() == MessageType.MAIN) {
-            session.incrementQuestionCount();
-        }
-
+        String transcript = conversationTurnService.sttAndSaveUserMessage(
+                audioFile,
+                session,
+                request.getLanguageCode(),
+                request.getMessageType()
+        );
 
         return new SttResponseDto(transcript);
     }
@@ -187,24 +169,11 @@ public class MySpeakService {
             throw new MySpeakException(MySpeakErrorCode.SESSION_NOT_FOUND);
         }
 
-        // TTS 변환
-        byte[] audioBytes = textSynthesisService.synthesize(
-                request.getText(),
+        return conversationTurnService.ttsAndSaveAiMessage(
+                session, request.getText(),
+                request.getMessageType(),
                 request.getVoiceName(),
-                request.getSpeakingRate()
-        );
-
-        //AI 메시지 저장
-        ConversationMessage aiMessage = ConversationMessage.builder()
-                .session(session)
-                .senderRole(SenderRole.AI)
-                .content(request.getText())
-                .messageType(request.getMessageType())
-                .build();
-
-        conversationMessageRepository.save(aiMessage);
-
-        return audioBytes;
+                request.getSpeakingRate());
     }
 
     /**
@@ -249,6 +218,50 @@ public class MySpeakService {
 
         return new CompleteSessionResponse(sessionId, request.getTotalTime(), sentenceCount, closingTtsBase64);
     }
+
+    @Transactional
+    public ConversationTurnResponse handelTurn(MultipartFile audioFile, Long sessionId, ConversationTurnRequest request) {
+        // 세션 조회
+        ConversationSession session = mySpeakRepository.findByIdWithAvatar(sessionId);
+        if (session == null) {
+            throw new MySpeakException(MySpeakErrorCode.SESSION_NOT_FOUND);
+        }
+
+
+
+        // STT + USER 메시지 저장
+        String userText = conversationTurnService.sttAndSaveUserMessage(
+                audioFile,
+                session,
+                request.getLanguageCode(),
+                request.getMessageType()
+        );
+
+        // AI 질문 생성 (지금은 더미)
+        //여기서 ai 질문 생성하는 메서드 호출 필요!!!!!
+        String aiQuestion = "Can you elaborate on that?";
+
+
+
+
+        Avatar avatar = session.getMyRole().getAvatar();
+
+        // TTS + AI 메시지 저장
+        byte[] audioBytes = conversationTurnService.ttsAndSaveAiMessage(
+                session,
+                aiQuestion,
+                MessageType.MAIN, //이부분 AI가 꼬리질문인지 메인 질문인지 판별한 다음 값 세팅 부탁
+                avatar.getTtsVoiceId(),
+                avatar.getCadenceType().getSpeedRate()
+        );
+
+        return new ConversationTurnResponse(
+                aiQuestion,
+                Base64.getEncoder().encodeToString(audioBytes),
+                MessageType.MAIN //이부분 AI가 꼬리질문인지 메인 질문인지 판별한 다음 값 세팅 부탁
+        );
+    }
+
 
     /**
      * 세션의 사용자 난이도 평가를 저장
@@ -300,22 +313,7 @@ public class MySpeakService {
                 .count();
     }
 
-    /**
-     * 업로드된 음성 파일 형식을 검증한다.
-     *
-     * @param file 업로드된 파일
-     * @throws MySpeakException 비어있거나 지원하지 않는 포맷일 경우
-     */
-    private void validateAudioFile(MultipartFile file) {
-        if (file == null || file.isEmpty()) {
-            throw new MySpeakException(MySpeakErrorCode.INVALID_AUDIO_FORMAT);
-        }
 
-        String filename = file.getOriginalFilename();
-        if (filename == null || !filename.matches("(?i).*\\.(m4a|wav|mp3|mp4|webm|ogg|flac|aac)$")) {
-            throw new MySpeakException(MySpeakErrorCode.INVALID_AUDIO_FORMAT);
-        }
-    }
 
     /**
      * MyRole 리스트 검증

--- a/src/main/java/com/example/speakOn/domain/mySpeak/service/S3UploaderService.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/service/S3UploaderService.java
@@ -23,10 +23,10 @@ public class S3UploaderService {
     private final S3Client s3Client;
     private final String s3BucketName;
 
-    public String uploadAudio(MultipartFile file, SttRequestDto requestDto) {
+    public String uploadAudio(MultipartFile file, Long sessionId) {
         try {
             String ext = getExtension(file.getOriginalFilename());
-            String key = "audio/" + requestDto.getSessionId() + "/" + UUID.randomUUID() + ext;
+            String key = "audio/" + sessionId + "/" + UUID.randomUUID() + ext;
 
             PutObjectRequest request = PutObjectRequest.builder()
                     .bucket(s3BucketName)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
 ✨ Feat: 대화 한턴 보장하는 API #67 

## 📝 작업 내용
- 프런트 ->STT -> 텍스트 변환 -> AI 질문 생성(구현하면 합칠 예정) 현재 샘플 -> TTS -> 음성파일 API 구현
- Avater 엔티티 cadenceType 코드 추가
- 기존  대화 종료 api 수정 
- 공용로직 코드 책임 분리 

## 📌 공유 사항
-  AI분 MySpeak 서비스 로직 handleTurn 메서드 꼭 보세요!

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷
<img width="1767" height="593" alt="image" src="https://github.com/user-attachments/assets/5a601eec-9f83-4c07-818c-0e63aec51a49" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 오디오 기반 대화 처리용 새 턴 API 및 응답 타입 추가
  * 아바타별 말하기 속도(빠름/보통/느림) 설정 적용

* **개선 사항**
  * STT/TTS 흐름 통합 및 저장 자동화로 처리 안정성 향상
  * 기본 언어 설정을 en-US로 변경

* **문서**
  * 멀티파트 턴 처리에 대한 API 문서화 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->