### PR TITLE
[#85] 🐛 Fix: 유저 테이블 이름 컬럼 길이 수정

### DIFF
--- a/src/main/java/com/example/speakOn/domain/user/entity/User.java
+++ b/src/main/java/com/example/speakOn/domain/user/entity/User.java
@@ -30,7 +30,7 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(name = "name", nullable = false, length = 10)
+    @Column(name = "name", nullable = false, length = 30)
     private String name;
 
     @Column(name = "nickname", length = 20)


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #85 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 구글 로그인 시 500 에러 발생 
  -> 유저 테이블의 name 컬럼 길이가 10으로 제한되어 있어 구글 소셜 로그인 시 전달되는 이름이 이를 초과하면서 DB 에러 발생 
  ->users.name 컬럼 길이를 30으로 확장

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
- 배포 DB에는 이미 반영되어 있고,로컬 환경에서는 필요 시 아래 쿼리를 실행해 주세요.
```sql
ALTER TABLE users
ALTER COLUMN name TYPE VARCHAR(30);
```
## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 사용자 이름 필드의 최대 문자 길이가 30자로 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->