### PR TITLE
[#89] 🐛 Fix: 마이롤 삭제 오류 해결

### DIFF
--- a/src/main/java/com/example/speakOn/domain/myRole/controller/MyRoleController.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/controller/MyRoleController.java
@@ -64,7 +64,7 @@ public class MyRoleController {
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_UNAUTHORIZED"),
             @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
     })
-    @DeleteMapping("/{myRoleId}")
+    @PatchMapping("/{myRoleId}")
     public ApiResponse<MyRoleResponse.DeleteMyRoleResultDTO> deleteMyRole(@PathVariable Long myRoleId) {
 
         Long userId = authUtil.getCurrentUserId();

--- a/src/main/java/com/example/speakOn/domain/myRole/entity/MyRole.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/entity/MyRole.java
@@ -39,4 +39,15 @@ public class MyRole extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "situation", nullable = false)
     private SituationType situation;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isActive = true;
+
+    /**
+     * 롤을 비활성화 (soft delete)
+     */
+    public void deactivate() {
+        this.isActive = false;
+    }
 }

--- a/src/main/java/com/example/speakOn/domain/myRole/entity/MyRole.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/entity/MyRole.java
@@ -50,4 +50,11 @@ public class MyRole extends BaseEntity {
     public void deactivate() {
         this.isActive = false;
     }
+
+    /**
+     * 롤을 다시 활성화 (soft delete 되었던 롤을 복구)
+     */
+    public void reactivate() {
+        this.isActive = true;
+    }
 }

--- a/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
@@ -12,10 +12,13 @@ import java.util.Optional;
 
 public interface MyRoleRepository extends JpaRepository<MyRole, Long>, MyRoleRepositoryCustom {
 
-    boolean existsByUserAndAvatarAndJobAndSituation(User user, Avatar avatar, JobType job, SituationType situation);
+    // 활성화된 롤 중복 체크 (soft delete 지원)
+    boolean existsByUserAndAvatarAndJobAndSituationAndIsActiveTrue(User user, Avatar avatar, JobType job, SituationType situation);
 
+    // 특정 사용자의 모든 활성화된 MyRole 조회 (최신순)
     List<MyRole> findByUserAndIsActiveTrueOrderByCreatedAtDesc(User user);
 
+    // ID와 활성화 상태로 MyRole 조회 (soft delete 지원)
     Optional<MyRole> findByIdAndIsActiveTrue(Long id);
 
 }

--- a/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
@@ -8,12 +8,14 @@ import com.example.speakOn.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MyRoleRepository extends JpaRepository<MyRole, Long>, MyRoleRepositoryCustom {
 
     boolean existsByUserAndAvatarAndJobAndSituation(User user, Avatar avatar, JobType job, SituationType situation);
 
-    // 특정 사용자의 모든 MyRole 조회 (최신순)
-    List<MyRole> findByUserOrderByCreatedAtDesc(User user);
+    List<MyRole> findByUserAndIsActiveTrueOrderByCreatedAtDesc(User user);
+
+    Optional<MyRole> findByIdAndIsActiveTrue(Long id);
 
 }

--- a/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
@@ -15,6 +15,9 @@ public interface MyRoleRepository extends JpaRepository<MyRole, Long>, MyRoleRep
     // 활성화된 롤 중복 체크 (soft delete 지원)
     boolean existsByUserAndAvatarAndJobAndSituationAndIsActiveTrue(User user, Avatar avatar, JobType job, SituationType situation);
 
+    // 비활성화된 롤 조회 (재활성화용)
+    Optional<MyRole> findByUserAndAvatarAndJobAndSituationAndIsActiveFalse(User user, Avatar avatar, JobType job, SituationType situation);
+
     // 특정 사용자의 모든 활성화된 MyRole 조회 (최신순)
     List<MyRole> findByUserAndIsActiveTrueOrderByCreatedAtDesc(User user);
 

--- a/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
@@ -94,7 +94,6 @@ public class MyRoleServiceImpl implements MyRoleService {
 
         // 4. Soft delete (isActive를 false로 변경)
         myRole.deactivate();
-        myRoleRepository.save(myRole);
 
         // 5. 응답 변환
         return MyRoleConverter.toDeleteMyRoleResultDTO(myRoleId);

--- a/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
@@ -69,7 +69,7 @@ public class MyRoleServiceImpl implements MyRoleService {
     }
 
     /**
-     * 롤 삭제 (hard delete - DB에서 실제 삭제)
+     * 롤 삭제 (soft delete - isActive를 false로 변경)
      *
      * @param userId   현재 로그인한 사용자 ID
      * @param myRoleId 삭제할 MyRole ID
@@ -83,8 +83,8 @@ public class MyRoleServiceImpl implements MyRoleService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 2. MyRole 조회
-        MyRole myRole = myRoleRepository.findById(myRoleId)
+        // 2. MyRole 조회 (active=true인 항목만)
+        MyRole myRole = myRoleRepository.findByIdAndIsActiveTrue(myRoleId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.MY_ROLE_NOT_FOUND));
 
         // 3. 권한 검증 - 본인의 롤인지 확인
@@ -92,8 +92,9 @@ public class MyRoleServiceImpl implements MyRoleService {
             throw new ErrorHandler(ErrorStatus.MY_ROLE_FORBIDDEN);
         }
 
-        // 4. Hard delete (DB에서 실제 삭제)
-        myRoleRepository.delete(myRole);
+        // 4. Soft delete (isActive를 false로 변경)
+        myRole.deactivate();
+        myRoleRepository.save(myRole);
 
         // 5. 응답 변환
         return MyRoleConverter.toDeleteMyRoleResultDTO(myRoleId);
@@ -103,7 +104,7 @@ public class MyRoleServiceImpl implements MyRoleService {
      * 롤 목록 조회
      *
      * @param userId 현재 로그인한 사용자 ID
-     * @return 사용자의 모든 롤 목록
+     * @return 사용자의 모든 롤 목록 (활성화된 롤만)
      */
     @Override
     public MyRoleResponse.MyRoleListDTO getMyRoles(Long userId) {
@@ -112,8 +113,8 @@ public class MyRoleServiceImpl implements MyRoleService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 2. 사용자의 모든 MyRole 조회 (최신순)
-        List<MyRole> myRoles = myRoleRepository.findByUserOrderByCreatedAtDesc(user);
+        // 2. 사용자의 모든 MyRole 조회 (최신순, active=true만)
+        List<MyRole> myRoles = myRoleRepository.findByUserAndIsActiveTrueOrderByCreatedAtDesc(user);
 
         // 3. 응답 변환
         return MyRoleConverter.toMyRoleListDTO(myRoles);

--- a/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -47,20 +48,31 @@ public class MyRoleServiceImpl implements MyRoleService {
         Avatar avatar = avatarRepository.findById(request.getAvatarId())
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.AVATAR_NOT_FOUND));
 
-        // 3. 중복 체크 (같은 user, avatar, job, situation 조합의 활성화된 롤이 이미 존재하는지)
-        boolean exists = myRoleRepository.existsByUserAndAvatarAndJobAndSituationAndIsActiveTrue(
+        // 3. 활성화된 롤 중복 체크
+        boolean activeExists = myRoleRepository.existsByUserAndAvatarAndJobAndSituationAndIsActiveTrue(
                 user, avatar, request.getJob(), request.getSituation());
-        if (exists) {
+        if (activeExists) {
             throw new ErrorHandler(ErrorStatus.MY_ROLE_ALREADY_EXISTS);
         }
 
-        // 4. MyRole 생성 및 저장
-        MyRole myRole = MyRole.builder()
-                .user(user)
-                .avatar(avatar)
-                .job(request.getJob())
-                .situation(request.getSituation())
-                .build();
+        // 4. 비활성화된 롤 조회 (삭제됐던 롤이 있으면 재활성화)
+        Optional<MyRole> inactiveRole = myRoleRepository.findByUserAndAvatarAndJobAndSituationAndIsActiveFalse(
+                user, avatar, request.getJob(), request.getSituation());
+
+        MyRole myRole;
+        if (inactiveRole.isPresent()) {
+            // 4-1. 비활성화된 롤이 있으면 재활성화
+            myRole = inactiveRole.get();
+            myRole.reactivate();
+        } else {
+            // 4-2. 없으면 새로운 롤 생성
+            myRole = MyRole.builder()
+                    .user(user)
+                    .avatar(avatar)
+                    .job(request.getJob())
+                    .situation(request.getSituation())
+                    .build();
+        }
 
         MyRole savedMyRole = myRoleRepository.save(myRole);
 

--- a/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/service/MyRoleServiceImpl.java
@@ -47,8 +47,8 @@ public class MyRoleServiceImpl implements MyRoleService {
         Avatar avatar = avatarRepository.findById(request.getAvatarId())
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.AVATAR_NOT_FOUND));
 
-        // 3. 중복 체크 (같은 user, avatar, job, situation 조합이 이미 존재하는지)
-        boolean exists = myRoleRepository.existsByUserAndAvatarAndJobAndSituation(
+        // 3. 중복 체크 (같은 user, avatar, job, situation 조합의 활성화된 롤이 이미 존재하는지)
+        boolean exists = myRoleRepository.existsByUserAndAvatarAndJobAndSituationAndIsActiveTrue(
                 user, avatar, request.getJob(), request.getSituation());
         if (exists) {
             throw new ErrorHandler(ErrorStatus.MY_ROLE_ALREADY_EXISTS);


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #89 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- My Role 엔티티에 `isActive` 추가
- Hard Delete -> Soft Delete 방식으로 변경
- My Role 조회시 활성화 되어있는 것만 조회하도록 변경
- 동일 조건의 role이 이미 존재하지만 `isActive = false`인 경우, 새로 생성하지 않고 `isActive`를 `true`로 변경하여 재활성화

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
- 마이롤은 단순 삭제해도 될 것이라 생각하였는데, `conversation_session`에서 참조 중인 상태여서 FK 오류가 발생했고, 이에 삭제 방식을 Soft Delete로 변경했습니다...

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 역할 삭제가 완전 삭제에서 비활성화(soft-delete)로 변경되어 데이터가 보존되고, 비활성화된 역할을 명시적으로 처리합니다.

* **버그 수정**
  * 목록 조회 및 중복 검사에서 활성 상태인 역할만 반환/검사하도록 개선되어 사용자에게 올바른 항목만 표시됩니다.
  * 삭제 관련 API의 HTTP 메서드가 변경되어 클라이언트 호출 방식이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->