### PR TITLE
[#63] ✨ 토스페이먼츠 연동, 구독 기능 구현

### DIFF
--- a/src/main/java/com/example/speakOn/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/controller/SubscriptionController.java
@@ -7,6 +7,7 @@ import com.example.speakOn.global.apiPayload.ApiResponse;
 import com.example.speakOn.global.util.AuthUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
@@ -30,7 +31,7 @@ public class SubscriptionController {
     @PostMapping("/confirm")
     @Operation(summary = "결제 승인", description = "토스페이먼츠 결제를 승인하고 구독을 생성합니다.")
     public ApiResponse<SubscriptionResponse.SubscriptionResponseDto> confirmPayment(
-            @RequestBody SubscriptionRequest.SubscriptionRequestDto request) {
+            @Valid @RequestBody SubscriptionRequest.SubscriptionRequestDto request) {
 
         Long userId = authUtil.getCurrentUserId();
         log.info("결제 승인 요청 - userId: {}, orderId: {}", userId, request.getOrderId());
@@ -40,4 +41,6 @@ public class SubscriptionController {
         return ApiResponse.onSuccess(response);
     }
 }
+
+
 

--- a/src/main/java/com/example/speakOn/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/controller/SubscriptionController.java
@@ -1,0 +1,43 @@
+package com.example.speakOn.domain.subscription.controller;
+
+import com.example.speakOn.domain.subscription.dto.SubscriptionRequest;
+import com.example.speakOn.domain.subscription.dto.SubscriptionResponse;
+import com.example.speakOn.domain.subscription.service.SubscriptionService;
+import com.example.speakOn.global.apiPayload.ApiResponse;
+import com.example.speakOn.global.util.AuthUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Subscription API", description = "구독 관련 API")
+@Slf4j
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/subscription")
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+    private final AuthUtil authUtil;
+
+    /**
+     * 구독 결제 승인
+     * 토스페이먼츠에서 전달받은 결제 정보를 확인하고 구독을 생성합니다.
+     */
+    @PostMapping("/confirm")
+    @Operation(summary = "결제 승인", description = "토스페이먼츠 결제를 승인하고 구독을 생성합니다.")
+    public ApiResponse<SubscriptionResponse.SubscriptionResponseDto> confirmPayment(
+            @RequestBody SubscriptionRequest.SubscriptionRequestDto request) {
+
+        Long userId = authUtil.getCurrentUserId();
+        log.info("결제 승인 요청 - userId: {}, orderId: {}", userId, request.getOrderId());
+
+        SubscriptionResponse.SubscriptionResponseDto response = subscriptionService.successSubscription(userId, request);
+
+        return ApiResponse.onSuccess(response);
+    }
+}
+

--- a/src/main/java/com/example/speakOn/domain/subscription/converter/SubscriptionConverter.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/converter/SubscriptionConverter.java
@@ -1,0 +1,22 @@
+package com.example.speakOn.domain.subscription.converter;
+
+import com.example.speakOn.domain.subscription.dto.SubscriptionResponse;
+import com.example.speakOn.domain.subscription.entity.Subscription;
+
+public class SubscriptionConverter {
+
+    /**
+     * Subscription 엔티티를 SubscriptionResponseDto로 변환
+     */
+    public static SubscriptionResponse.SubscriptionResponseDto toSubscriptionResponseDto(Subscription subscription) {
+        return SubscriptionResponse.SubscriptionResponseDto.builder()
+                .subscriptionId(subscription.getId())
+                .orderName(subscription.getOrderName())
+                .amount(subscription.getAmount())
+                .approvedAt(subscription.getApprovedAt())
+                .expiredAt(subscription.getExpiredAt())
+                .orderId(subscription.getOrderId())
+                .message("구독이 완료되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/subscription/dto/SubscriptionRequest.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/dto/SubscriptionRequest.java
@@ -1,0 +1,30 @@
+package com.example.speakOn.domain.subscription.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SubscriptionRequest {
+
+    @Schema(description = "구독 결제 요청 DTO")
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SubscriptionRequestDto {
+
+        @Schema(description = "토스페이먼츠 결제 키", example = "toss_paymentkey_1234567890")
+        @NotBlank(message = "paymentKey는 필수입니다.")
+        private String paymentKey;
+
+        @Schema(description = "주문 ID", example = "order_1234567890")
+        @NotBlank(message = "orderId는 필수입니다.")
+        private String orderId;
+
+        @Schema(description = "결제 금액", example = "3900")
+        @NotNull(message = "amount는 필수입니다.")
+        private Long amount;
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/subscription/dto/SubscriptionResponse.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/dto/SubscriptionResponse.java
@@ -1,0 +1,41 @@
+package com.example.speakOn.domain.subscription.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public class SubscriptionResponse {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "구독 결제 승인 응답 DTO")
+    public static class SubscriptionResponseDto {
+
+        @Schema(description = "구독 ID", example = "1")
+        private Long subscriptionId;
+
+        @Schema(description = "주문명", example = "Conversation Record Plan")
+        private String orderName;
+
+        @Schema(description = "결제 금액", example = "3900")
+        private Long amount;
+
+        @Schema(description = "구독 시작일", example = "2026-02-07T10:30:00")
+        private LocalDateTime approvedAt;
+
+        @Schema(description = "구독 만료일", example = "2026-03-09T10:30:00")
+        private LocalDateTime expiredAt;
+
+        @Schema(description = "주문 ID", example = "order_20260207_123456")
+        private String orderId;
+
+        @Schema(description = "구독 상태 메시지", example = "구독이 완료되었습니다.")
+        private String message;
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/entity/Subscription.java
@@ -1,0 +1,54 @@
+package com.example.speakOn.domain.subscription.entity;
+
+import com.example.speakOn.domain.user.entity.User;
+import com.example.speakOn.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Subscription extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    // 토스페이먼츠 주문 ID
+    @Column(nullable = false, unique = true)
+    private String orderId;
+
+    @Column(nullable = false)
+    private String orderName;
+
+    // 만료일
+    private LocalDateTime expiredAt;
+
+    // 토스페이먼츠 결제 키
+    private String paymentKey;
+
+    // 결제 완료 시간
+    private LocalDateTime approvedAt;
+
+    public static Subscription createSubscription(User user, String orderId, String orderName, Long amount, String paymentKey) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return Subscription.builder()
+                .user(user)
+                .orderId(orderId)
+                .orderName(orderName)
+                .amount(amount)
+                .paymentKey(paymentKey)
+                .approvedAt(now)
+                .expiredAt(now.plusDays(30)) // 만료기준 : +30일
+                .build();
+    }
+}
+

--- a/src/main/java/com/example/speakOn/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,20 @@
+package com.example.speakOn.domain.subscription.repository;
+
+import com.example.speakOn.domain.subscription.entity.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    /**
+     * 유저의 유효한 구독 정보 조회 (현재 시간 기준 만료되지 않음)
+     */
+    @Query("SELECT s FROM Subscription s WHERE s.user.id = :userId AND s.expiredAt > :currentTime")
+    Optional<Subscription> findActiveSubscriptionByUserId(@Param("userId") Long userId, @Param("currentTime") LocalDateTime currentTime);
+}

--- a/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionService.java
@@ -1,0 +1,10 @@
+package com.example.speakOn.domain.subscription.service;
+
+import com.example.speakOn.domain.subscription.dto.SubscriptionRequest;
+import com.example.speakOn.domain.subscription.dto.SubscriptionResponse;
+
+public interface SubscriptionService {
+
+    SubscriptionResponse.SubscriptionResponseDto successSubscription(Long userId, SubscriptionRequest.SubscriptionRequestDto request);
+
+}

--- a/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionServiceImpl.java
@@ -1,0 +1,67 @@
+package com.example.speakOn.domain.subscription.service;
+
+import com.example.speakOn.domain.subscription.converter.SubscriptionConverter;
+import com.example.speakOn.domain.subscription.dto.SubscriptionRequest;
+import com.example.speakOn.domain.subscription.dto.SubscriptionResponse;
+import com.example.speakOn.domain.subscription.entity.Subscription;
+import com.example.speakOn.domain.subscription.repository.SubscriptionRepository;
+import com.example.speakOn.domain.user.entity.User;
+import com.example.speakOn.domain.user.repository.UserRepository;
+import com.example.speakOn.global.apiPayload.code.status.ErrorStatus;
+import com.example.speakOn.global.apiPayload.exception.handler.ErrorHandler;
+import com.example.speakOn.global.util.TossPaymentUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscriptionServiceImpl implements SubscriptionService {
+
+    private final TossPaymentUtil tossPaymentUtil;
+    private final UserRepository userRepository;
+    private final SubscriptionRepository subscriptionRepository;
+
+    // 결제 금액 고정값
+    private final Long SUBSCRIPTION_AMOUNT = 3900L;
+
+    @Transactional
+    @Override
+    public SubscriptionResponse.SubscriptionResponseDto successSubscription(Long userId, SubscriptionRequest.SubscriptionRequestDto request) {
+
+        // 1. 금액 검증
+        if (!SUBSCRIPTION_AMOUNT.equals(request.getAmount())) {
+            throw new RuntimeException("결제 금액이 올바르지 않습니다.");
+        }
+
+        // 2. 토스페이먼츠 결제 승인 요청
+        tossPaymentUtil.confirm(
+                request.getPaymentKey(),
+                request.getOrderId(),
+                request.getAmount()
+        );
+
+        // 3. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 4. 구독 정보 생성
+        Subscription subscription = Subscription.createSubscription(
+                user,
+                request.getOrderId(),
+                "Conversation Record Plan",
+                request.getAmount(),
+                request.getPaymentKey()
+        );
+
+        // 5. 구독 정보 저장
+        Subscription savedSubscription = subscriptionRepository.save(subscription);
+
+        // 6. 응답 DTO 반환
+        return SubscriptionConverter.toSubscriptionResponseDto(savedSubscription);
+
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionServiceImpl.java
@@ -37,16 +37,17 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             throw new RuntimeException("결제 금액이 올바르지 않습니다.");
         }
 
-        // 2. 토스페이먼츠 결제 승인 요청
+        // 2. 유저 조회 (결제 승인 전에 수행)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 3. 토스페이먼츠 결제 승인 요청
         tossPaymentUtil.confirm(
                 request.getPaymentKey(),
                 request.getOrderId(),
                 request.getAmount()
         );
 
-        // 3. 유저 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 4. 구독 정보 생성
         Subscription subscription = Subscription.createSubscription(

--- a/src/main/java/com/example/speakOn/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/example/speakOn/domain/user/converter/UserConverter.java
@@ -2,13 +2,17 @@ package com.example.speakOn.domain.user.converter;
 
 import com.example.speakOn.domain.user.dto.UserResponse;
 import com.example.speakOn.domain.user.entity.User;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
 
 public class UserConverter {
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
-
-    public static UserResponse.MyPageResponseDTO toMyPageResponseDTO(User user) {
+    /**
+     * User 엔티티와 구독 정보를 포함한 마이페이지 응답 DTO로 변환
+     */
+    public static UserResponse.MyPageResponseDTO toMyPageResponseDTO(
+            User user,
+            Boolean isSubscribed,
+            LocalDateTime subscriptionExpiredAt) {
 
         return UserResponse.MyPageResponseDTO.builder()
                 .userId(user.getId())
@@ -17,7 +21,9 @@ public class UserConverter {
                 .name(user.getName())
                 .email(user.getEmail())
                 .socialType(user.getSocialType())
-                .createdAt(user.getCreatedAt().format(DATE_FORMATTER))
+                .createdAt(user.getCreatedAt())
+                .isSubscribed(isSubscribed)
+                .subscriptionExpiredAt(subscriptionExpiredAt)
                 .build();
     }
 }

--- a/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 public class UserResponse {
 
     @Builder
@@ -34,8 +36,17 @@ public class UserResponse {
         @Schema(description = "소셜 로그인 타입", example = "GOOGLE")
         private SocialType socialType;
 
-        @Schema(description = "서비스 가입일", example = "2025.12.19")
-        private String createdAt;
+        @Schema(description = "서비스 가입일", example = "2026-01-24T20:56:20.663238")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "구독 여부", example = "true")
+        private Boolean isSubscribed;
+
+        @Schema(description = "구독 만료일", example = "2026-01-24T20:56:20.663238")
+        private LocalDateTime subscriptionExpiredAt;
 
     }
 }
+
+
+

--- a/src/main/java/com/example/speakOn/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/user/service/UserQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.speakOn.domain.user.service;
 
+import com.example.speakOn.domain.subscription.repository.SubscriptionRepository;
 import com.example.speakOn.domain.user.converter.UserConverter;
 import com.example.speakOn.domain.user.dto.UserResponse;
 import com.example.speakOn.domain.user.entity.User;
@@ -11,6 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserRepository userRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     // User 존재 여부 검증
     @Override
@@ -33,8 +37,17 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 2. 응답 DTO 반환
-        return UserConverter.toMyPageResponseDTO(user);
+        // 2. 구독 정보 조회
+        var activeSubscription = subscriptionRepository
+                .findActiveSubscriptionByUserId(userId, LocalDateTime.now());
+
+        Boolean isSubscribed = activeSubscription.isPresent();
+        LocalDateTime subscriptionExpiredAt = activeSubscription
+                .map(subscription -> subscription.getExpiredAt())
+                .orElse(null);
+
+        // 3. 응답 DTO 반환
+        return UserConverter.toMyPageResponseDTO(user, isSubscribed, subscriptionExpiredAt);
     }
 
     // 온보딩 완료

--- a/src/main/java/com/example/speakOn/global/util/TossPaymentUtil.java
+++ b/src/main/java/com/example/speakOn/global/util/TossPaymentUtil.java
@@ -1,0 +1,48 @@
+package com.example.speakOn.global.util;
+
+import net.minidev.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+public class TossPaymentUtil {
+
+    @Value("${toss.secret-key}")
+    private String tossSecretKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void confirm(String paymentKey, String orderId, Long amount) {
+        HttpHeaders headers = new HttpHeaders();
+        // 시크릿 키를 Base64로 인코딩해서 헤더에 넣음 (토스 규칙)
+        String encodedAuth = Base64.getEncoder().encodeToString((tossSecretKey + ":").getBytes(StandardCharsets.UTF_8));
+        headers.set("Authorization", "Basic " + encodedAuth);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        JSONObject params = new JSONObject();
+        params.put("paymentKey", paymentKey);
+        params.put("orderId", orderId);
+        params.put("amount", amount);
+
+        HttpEntity<String> entity = new HttpEntity<>(params.toString(), headers);
+
+        try {
+            // 토스 승인 API 호출!
+            restTemplate.postForEntity(
+                    "https://api.tosspayments.com/v1/payments/confirm",
+                    entity,
+                    String.class
+            );
+        } catch (Exception e) {
+            // 실패하면 여기서 에러가 터지고, Service의 트랜잭션이 롤백됨
+            throw new RuntimeException("토스 결제 승인 실패: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #63 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
토스 페이먼츠 API를 연동하여 사용자의 결제 요청을 검증하고, 승인 완료 시 구독 데이터를 생성하는 로직을 구현했습니다.
#### Subscription 엔티티 및 Repository 구현
- Subscription 엔티티 생성 (User와 ManyToOne 관계)
- `createSubscription()` - 구독 정보 생성 (+30일 만료)
- `findActiveSubscriptionByUserId()` 쿼리 메서드 추가 - 만료일과 현재 시간 비교

#### Subscription 서비스 계층 구현
- 결제 금액 검증 → 토스 승인 → 구독 저장

#### 구독 결제 API 구현
- 엔드포인트 : `POST /api/subscription/confirm`
- 토스페이먼츠 결제 승인 요청 처리
- 구독 정보 반환
```
1. 금액 검증
   └─ request.amount == 3900? → No → RuntimeException

2. 토스페이먼츠 결제 승인
   └─ tossPaymentUtil.confirm(paymentKey, orderId, amount)
   └─ 실패 시 예외 발생

3. 사용자 조회
   └─ userRepository.findById(userId)
   └─ 없으면 → ErrorStatus.USER_NOT_FOUND

4. Subscription 엔티티 생성
   └─ Subscription.createSubscription(user, orderId, orderName, amount, paymentKey)
   └─ approvedAt = 현재 시간
   └─ expiredAt = 현재 시간 + 30일

5. DB 저장
   └─ subscriptionRepository.save(subscription)

6. 응답 DTO 반환
   └─ SubscriptionConverter.toSubscriptionResponseDto(savedSubscription)
```
#### 마이페이지에 구독 정보 조회 기능 추가
- `UserResponse.MyPageResponseDTO`에 필드 추가
  * isSubscribed: 구독 여부 (boolean)
  * subscriptionExpiredAt: 구독 만료일 (LocalDateTime)
- `UserQueryServiceImpl.getMyPageInfo()` 수정
  * 유효한 구독 정보 함께 조회
  * 현재 시간 기준 유효한 구독만 반환
 
## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  현재 적용된 토스 페이먼츠 키는 '테스트용 키'입니다. 실제로 결제 프로세스를 진행해도 비용이 청구되지 않으며, 가상으로 승인 처리됩니다.

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 구독 결제 승인 처리 및 확인 기능 추가 — 결제 완료 시 구독이 활성화됩니다.
  * 구독 결제 승인 응답에 구독 ID, 금액, 승인/만료 시각 및 안내 메시지 제공

* **개선**
  * 마이페이지에 구독 활성 상태와 만료일 실시간 표시
  * 구독 생성 시 만료일 자동 설정(30일) 및 활성 여부 즉시 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->