### PR TITLE
[#94] ✨Feat: 리포트 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/speakOn/domain/myReport/code/MyReportErrorCode.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/code/MyReportErrorCode.java
@@ -21,9 +21,6 @@ public enum MyReportErrorCode implements BaseCode {
     INVALID_REPORT_FILTER(HttpStatus.BAD_REQUEST, "REPORT4003", "잘못된 직무 또는 상황 필터 조건입니다."),
     INVALID_PAGE_PARAMETER(HttpStatus.BAD_REQUEST, "REPORT4004", "페이지 번호는 0보다 커야 합니다."),
 
-    // 비즈니스 로직 관련 (다시 듣기)
-    REPLAY_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "REPORT4005", "무료 다시 듣기 5회 횟수를 모두 소진하였습니다. 구독이 필요합니다."),
-
     // AI가 분석중인 경우
     REPORT_ANALYSIS_PENDING(HttpStatus.BAD_REQUEST, "REPORT4007", "AI가 아직 대화를 분석 중입니다. 잠시 후 다시 시도해 주세요."),
 

--- a/src/main/java/com/example/speakOn/domain/myReport/controller/MyReportController.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/controller/MyReportController.java
@@ -73,10 +73,15 @@ public class MyReportController implements MyReportControllerDocs {
     public ApiResponse<MyReportResponseDTO.ReportDetailDTO> generateReport(
             @PathVariable(name = "sessionId") Long sessionId) {
 
-        // 팀의 컨벤션인 authUtil을 그대로 사용합니다.
         Long userId = authUtil.getCurrentUserId();
 
-        // 서비스 단에서 권한 검증 로직이 포함되어 있으므로 바로 호출합니다.
         return ApiResponse.onSuccess(myReportService.generateReport(sessionId));
+    }
+
+    @Override
+    @DeleteMapping("/{reportId}")
+    public ApiResponse<MyReportResponseDTO.DeleteReportResultDTO> deleteReport(@PathVariable(name = "reportId") Long reportId) {
+        Long userId = authUtil.getCurrentUserId();
+        return ApiResponse.onSuccess(myReportService.deleteReport(reportId, userId));
     }
 }

--- a/src/main/java/com/example/speakOn/domain/myReport/converter/MyReportConverter.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/converter/MyReportConverter.java
@@ -10,6 +10,7 @@ import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -168,6 +169,13 @@ public class MyReportConverter {
                 .listSize(reportList.size())
                 .isFirst(reportSlice.isFirst())
                 .isLast(reportSlice.isLast())
+                .build();
+    }
+
+    public static MyReportResponseDTO.DeleteReportResultDTO toDeleteReportResultDTO(Long reportId) {
+        return MyReportResponseDTO.DeleteReportResultDTO.builder()
+                .reportId(reportId)
+                .deletedAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/example/speakOn/domain/myReport/docs/MyReportControllerDocs.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/docs/MyReportControllerDocs.java
@@ -77,4 +77,12 @@ public interface MyReportControllerDocs {
 
     @Operation(summary = "리포트 AI 분석 생성 API", description = "대화 세션을 분석하여 리포트를 생성합니다.")
     ApiResponse<MyReportResponseDTO.ReportDetailDTO> generateReport(Long sessionId);
+
+    @Operation(summary = "리포트 삭제 API", description = "특정 리포트를 삭제합니다. 관련된 AI 분석 데이터와 교정 내역이 함께 삭제되지만, 대화 로그(Session)는 유지됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REPORT4041", description = "해당 ID의 리포트를 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REPORT4031", description = "본인의 리포트만 삭제할 수 있습니다.")
+    })
+    ApiResponse<MyReportResponseDTO.DeleteReportResultDTO> deleteReport(@PathVariable(name = "reportId") Long reportId);
 }

--- a/src/main/java/com/example/speakOn/domain/myReport/dto/response/MyReportResponseDTO.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/dto/response/MyReportResponseDTO.java
@@ -194,4 +194,18 @@ public class MyReportResponseDTO {
         @Schema(description = "수정 완료 시각")
         LocalDateTime updatedAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "리포트 삭제 응답 DTO")
+    public static class DeleteReportResultDTO {
+
+        @Schema(description = "삭제된 리포트 ID", example = "101")
+        private Long reportId;
+
+        @Schema(description = "삭제 시간")
+        private LocalDateTime deletedAt;
+    }
 }

--- a/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
@@ -243,4 +243,20 @@ public class MyReportService {
                         .build())
                 .collect(Collectors.toList());
     }
+
+    /**
+     * 리포트 삭제
+     */
+    @Transactional
+    public MyReportResponseDTO.DeleteReportResultDTO deleteReport(Long reportId, Long userId) {
+        User user = findUser(userId);
+
+        MyReport report = myReportRepository.findById(reportId)
+                .orElseThrow(() -> new MyReportException(MyReportErrorCode.REPORT_NOT_FOUND));
+
+        validateReportOwner(report, user);
+        myReportRepository.delete(report);
+
+        return MyReportConverter.toDeleteReportResultDTO(reportId);
+    }
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #94 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- My Report 삭제 기능을 구현했습니다.
- 리포트 삭제 시 `Cascade.ALL` 설정에 의해 연관된 `ConversationTone`, `ConversationCorrection` 데이터도 함께 삭제되도록 처리하였습니다
- 본인의 리포트가 아닌 경우 `REPORT4031` 에러가 발생하도록 검증 로직을 추가하였습니다.
- Service의 `deleteReport` 메서드에서 하드 delete 방식을 사용하였습니다.

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [ ] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 리포트 삭제 기능이 추가되었습니다. 사용자는 본인의 리포트를 삭제할 수 있으며, 삭제 시 리포트 ID와 삭제 시간이 응답으로 반환됩니다.

* **Bug Fixes**
  * 무료 재청 횟수 초과 관련 에러 코드 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->