### PR TITLE
[#96] ✨ Feat: 프로필 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/example/speakOn/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/speakOn/domain/user/controller/UserController.java
@@ -1,6 +1,9 @@
 package com.example.speakOn.domain.user.controller;
 
+import com.example.speakOn.domain.user.converter.UserConverter;
+import com.example.speakOn.domain.user.dto.UserRequest;
 import com.example.speakOn.domain.user.dto.UserResponse;
+import com.example.speakOn.domain.user.service.UserCommandService;
 import com.example.speakOn.domain.user.service.UserQueryService;
 import com.example.speakOn.global.apiPayload.ApiResponse;
 import com.example.speakOn.global.apiPayload.code.status.ErrorStatus;
@@ -13,10 +16,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User API", description = "유저에 관한 API")
 @Slf4j
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
     private final AuthUtil authUtil;
 
     // 마이페이지
@@ -67,5 +69,34 @@ public class UserController {
 
         userQueryService.completeOnboarding(userId);
         return ApiResponse.onSuccess(null);
+    }
+
+    // 프로필 수정
+    @Operation(
+            summary = "프로필 정보 수정 API",
+            description = "닉네임과 프로필 이미지를 수정합니다. (이미지는 S3에 업로드됩니다)"
+    )
+    @ApiSuccessCodeExample(resultClass = UserResponse.UpdateProfileResponseDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_UNAUTHORIZED"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_BAD_REQUEST"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @PatchMapping(value = "/profile", consumes = {"multipart/form-data"})
+    public ApiResponse<UserResponse.UpdateProfileResponseDTO> updateProfile(
+            @RequestPart(value = "nickname", required = false) String nickname,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+
+        Long userId = authUtil.getCurrentUserId();
+        log.info("프로필 수정 요청 - userId: {}, nickname: {}, hasImage: {}",
+                userId, nickname, profileImage != null);
+
+        // Converter를 사용하여 Request DTO 생성
+        UserRequest.UpdateProfileRequestDto request = UserConverter.toUpdateProfileRequestDto(nickname, profileImage);
+
+        UserResponse.UpdateProfileResponseDTO response = userCommandService.updateProfile(userId, request);
+
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/speakOn/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/example/speakOn/domain/user/converter/UserConverter.java
@@ -1,10 +1,26 @@
 package com.example.speakOn.domain.user.converter;
 
+import com.example.speakOn.domain.user.dto.UserRequest;
 import com.example.speakOn.domain.user.dto.UserResponse;
 import com.example.speakOn.domain.user.entity.User;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.time.LocalDateTime;
 
 public class UserConverter {
+
+    /**
+     * 프로필 수정 요청 데이터로부터 Request DTO 생성
+     */
+    public static UserRequest.UpdateProfileRequestDto toUpdateProfileRequestDto(
+            String nickname,
+            MultipartFile profileImage) {
+
+        return UserRequest.UpdateProfileRequestDto.builder()
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .build();
+    }
 
     /**
      * User 엔티티와 구독 정보를 포함한 마이페이지 응답 DTO로 변환
@@ -24,6 +40,21 @@ public class UserConverter {
                 .createdAt(user.getCreatedAt())
                 .isSubscribed(isSubscribed)
                 .subscriptionExpiredAt(subscriptionExpiredAt)
+                .build();
+    }
+
+    /**
+     * 프로필 수정 후 응답 DTO로 변환
+     */
+    public static UserResponse.UpdateProfileResponseDTO toUpdateProfileResponseDTO(
+            User user,
+            String message) {
+
+        return UserResponse.UpdateProfileResponseDTO.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImgUrl(user.getProfileImgUrl())
+                .message(message)
                 .build();
     }
 }

--- a/src/main/java/com/example/speakOn/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/example/speakOn/domain/user/dto/UserRequest.java
@@ -1,0 +1,25 @@
+package com.example.speakOn.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+public class UserRequest {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "프로필 정보 수정 요청 DTO")
+    public static class UpdateProfileRequestDto {
+
+        @Schema(description = "변경할 닉네임 (선택사항)", example = "newNickname")
+        private String nickname;
+
+        @Schema(description = "프로필 이미지 파일 (선택사항)", type = "string", format = "binary")
+        private MultipartFile profileImage;
+    }
+}

--- a/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
@@ -46,7 +46,24 @@ public class UserResponse {
         private LocalDateTime subscriptionExpiredAt;
 
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "프로필 수정 응답 DTO")
+    public static class UpdateProfileResponseDTO {
+
+        @Schema(description = "유저 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "변경된 닉네임", example = "newNickname")
+        private String nickname;
+
+        @Schema(description = "변경된 프로필 이미지 URL", example = "https://bucket.s3.region.amazonaws.com/profile/uuid_filename.jpg")
+        private String profileImgUrl;
+
+        @Schema(description = "수정 완료 메시지", example = "프로필이 성공적으로 수정되었습니다.")
+        private String message;
+    }
 }
-
-
-

--- a/src/main/java/com/example/speakOn/domain/user/entity/User.java
+++ b/src/main/java/com/example/speakOn/domain/user/entity/User.java
@@ -54,6 +54,20 @@ public class User extends BaseEntity {
         this.profileImgUrl = profileImgUrl;
     }
 
+    /**
+     * 닉네임 수정
+     */
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    /**
+     * 프로필 이미지 URL 수정
+     */
+    public void updateProfileImage(String profileImgUrl) {
+        this.profileImgUrl = profileImgUrl;
+    }
+
     // 온보딩 완료
     public void completeOnboarding() {
         this.isOnboarded = true;

--- a/src/main/java/com/example/speakOn/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/speakOn/domain/user/service/UserCommandService.java
@@ -1,0 +1,17 @@
+package com.example.speakOn.domain.user.service;
+
+import com.example.speakOn.domain.user.dto.UserRequest;
+import com.example.speakOn.domain.user.dto.UserResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface UserCommandService {
+
+    /**
+     * 사용자 프로필 정보를 수정
+     * (닉네임, 프로필 이미지)
+     */
+    UserResponse.UpdateProfileResponseDTO updateProfile(
+            Long userId,
+            UserRequest.UpdateProfileRequestDto request
+    );
+}

--- a/src/main/java/com/example/speakOn/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/user/service/UserCommandServiceImpl.java
@@ -1,0 +1,72 @@
+package com.example.speakOn.domain.user.service;
+
+import com.example.speakOn.domain.user.converter.UserConverter;
+import com.example.speakOn.domain.user.dto.UserRequest;
+import com.example.speakOn.domain.user.dto.UserResponse;
+import com.example.speakOn.domain.user.entity.User;
+import com.example.speakOn.domain.user.repository.UserRepository;
+import com.example.speakOn.global.apiPayload.code.status.ErrorStatus;
+import com.example.speakOn.global.apiPayload.exception.handler.ErrorHandler;
+import com.example.speakOn.global.util.S3Util;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserCommandServiceImpl implements UserCommandService {
+
+    private final UserRepository userRepository;
+    private final S3Util s3Util;
+
+    @Override
+    @Transactional
+    public UserResponse.UpdateProfileResponseDTO updateProfile(
+            Long userId,
+            UserRequest.UpdateProfileRequestDto request) {
+
+        // 1. 입력값 검증 - 닉네임이나 프로필 이미지 중 최소 1개는 필수
+        if ((request.getNickname() == null || request.getNickname().trim().isEmpty()) &&
+            (request.getProfileImage() == null || request.getProfileImage().isEmpty())) {
+            throw new ErrorHandler(ErrorStatus.PROFILE_UPDATE_FAILED);
+        }
+
+        // 2. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 3. 기존 프로필 이미지 URL 저장 (삭제용)
+        String oldProfileImgUrl = user.getProfileImgUrl();
+
+        // 4. 닉네임 수정
+        if (request.getNickname() != null && !request.getNickname().trim().isEmpty()) {
+            user.updateNickname(request.getNickname());
+        }
+
+        // 5. 프로필 이미지 수정
+        if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()) {
+            // 새로운 이미지 S3 업로드
+            String newProfileImgUrl = s3Util.uploadFile(request.getProfileImage(), "profile");
+            user.updateProfileImage(newProfileImgUrl);
+            // 기존 이미지 삭제
+            if (oldProfileImgUrl != null && !oldProfileImgUrl.isEmpty()) {
+                try {
+                    s3Util.deleteFile(oldProfileImgUrl);
+                } catch (Exception e) {
+                }
+            }
+        }
+
+        // 6. 사용자 정보 저장
+        User updatedUser = userRepository.save(user);
+
+        // 7. 응답 DTO 반환
+        return UserConverter.toUpdateProfileResponseDTO(
+                updatedUser,
+                "프로필이 성공적으로 수정되었습니다."
+        );
+    }
+}

--- a/src/main/java/com/example/speakOn/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/speakOn/global/apiPayload/code/status/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseCode {
 
     // 유저 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER401", "아이디와 일치하는 사용자가 없습니다."),
+    PROFILE_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "USER400", "닉네임 또는 프로필 이미지 중 최소 1개를 입력해주세요."),
 
     // MyRole 관련 에러
     AVATAR_NOT_FOUND(HttpStatus.NOT_FOUND, "ROLE404", "존재하지 않는 아바타입니다."),

--- a/src/main/java/com/example/speakOn/global/util/S3Util.java
+++ b/src/main/java/com/example/speakOn/global/util/S3Util.java
@@ -1,0 +1,121 @@
+package com.example.speakOn.global.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Util {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket:myspeak-audio-storage}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static:ap-northeast-2}")
+    private String region;
+
+    /**
+     * 파일을 S3에 업로드합니다.
+     *
+     * @param file 업로드할 파일
+     * @param directory 저장할 디렉토리
+     * @return S3 URL
+     */
+    public String uploadFile(MultipartFile file, String directory) {
+        try {
+            // 파일명 생성 (UUID + 원본 파일명)
+            String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+            String key = directory + "/" + fileName;
+
+            // S3에 파일 업로드
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            PutObjectResponse response = s3Client.putObject(
+                    putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+            );
+
+            log.info("S3 업로드 성공 - key: {}, etag: {}", key, response.eTag());
+
+            // S3 URL 생성
+            return buildS3Url(key);
+
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 실패", e);
+            throw new RuntimeException("파일 업로드에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * S3에서 파일을 삭제합니다.
+     */
+    public void deleteFile(String fileUrl) {
+        try {
+            // URL에서 key 추출
+            String key = extractKeyFromUrl(fileUrl);
+
+            if (key == null || key.isEmpty()) {
+                log.warn("삭제할 파일의 key를 추출할 수 없습니다. - url: {}", fileUrl);
+                return;
+            }
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("S3 파일 삭제 성공 - key: {}", key);
+
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 실패 - url: {}", fileUrl, e);
+        }
+    }
+
+    /**
+     * S3 URL을 생성합니다.
+     *
+     * @param key S3 객체 키
+     * @return S3 URL
+     */
+    private String buildS3Url(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+    }
+
+    /**
+     * S3 URL에서 key를 추출합니다.
+     *
+     * @param fileUrl S3 URL
+     * @return S3 객체 키
+     */
+    private String extractKeyFromUrl(String fileUrl) {
+        if (fileUrl == null || fileUrl.isEmpty()) {
+            return null;
+        }
+
+        String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucketName, region);
+        if (fileUrl.startsWith(prefix)) {
+            return fileUrl.substring(prefix.length());
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #96 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
사용자가 마이페이지에서 닉네임과 프로필 이미지를 수정할 수 있는 기능을 구현했습니다. 프로필 이미지는 AWS S3에 업로드되며, 새로운 이미지 업로드 시 기존 이미지는 자동으로 삭제됩니다.
#### 프로필 정보 수정API 구현
- 엔드포인트 : `PATCH /api/user/profile`
- 요청값 : 
   - nickname (선택사항): 변경할 닉네임
   - profileImage (선택사항): 변경할 프로필 이미지 파일
- 로직
   - 입력값 검증 (닉네임 또는 이미지 중 최소 1개)
   - 사용자 존재 여부 확인
   - 기존 이미지 URL 저장
   - 닉네임 업데이트 (선택)
   - 이미지 업로드 및 기존 이미지 삭제 (선택)
   - 변경사항 저장

#### `S3Util` 구현
- uploadFile(): 파일을 S3에 업로드하고 URL 반환
- deleteFile(): S3에서 파일 삭제
- buildS3Url(): S3 URL 생성
- extractKeyFromUrl(): S3 URL에서 key 추출

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 프로필 편집 기능 추가: 닉네임 및 프로필 이미지 변경 가능
  * 프로필 이미지 클라우드 스토리지 연동으로 안정적인 이미지 관리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->