### PR TITLE
[#98] ✨ Feat: 구독 해지 기능 구현

### DIFF
--- a/src/main/java/com/example/speakOn/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/controller/SubscriptionController.java
@@ -40,6 +40,22 @@ public class SubscriptionController {
 
         return ApiResponse.onSuccess(response);
     }
+
+    /**
+     * 구독 해지
+     * 현재 활성 구독을 해지합니다.
+     */
+    @DeleteMapping("/cancel")
+    @Operation(summary = "구독 해지", description = "현재 활성 구독을 해지합니다.")
+    public ApiResponse<SubscriptionResponse.CancelSubscriptionResponseDto> cancelSubscription() {
+
+        Long userId = authUtil.getCurrentUserId();
+        log.info("구독 해지 요청 - userId: {}", userId);
+
+        SubscriptionResponse.CancelSubscriptionResponseDto response = subscriptionService.cancelSubscription(userId);
+
+        return ApiResponse.onSuccess(response);
+    }
 }
 
 

--- a/src/main/java/com/example/speakOn/domain/subscription/converter/SubscriptionConverter.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/converter/SubscriptionConverter.java
@@ -19,4 +19,15 @@ public class SubscriptionConverter {
                 .message("구독이 완료되었습니다.")
                 .build();
     }
+
+    /**
+     * 구독 해지 응답 DTO 생성
+     */
+    public static SubscriptionResponse.CancelSubscriptionResponseDto toCancelSubscriptionResponseDto(Subscription subscription) {
+        return SubscriptionResponse.CancelSubscriptionResponseDto.builder()
+                .subscriptionId(subscription.getId())
+                .cancelledAt(subscription.getCancelledAt())
+                .message("구독이 해지되었습니다.")
+                .build();
+    }
 }

--- a/src/main/java/com/example/speakOn/domain/subscription/dto/SubscriptionResponse.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/dto/SubscriptionResponse.java
@@ -38,4 +38,21 @@ public class SubscriptionResponse {
         @Schema(description = "구독 상태 메시지", example = "구독이 완료되었습니다.")
         private String message;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "구독 해지 응답 DTO")
+    public static class CancelSubscriptionResponseDto {
+
+        @Schema(description = "구독 ID", example = "1")
+        private Long subscriptionId;
+
+        @Schema(description = "해지 시간", example = "2026-02-08T10:30:00")
+        private LocalDateTime cancelledAt;
+
+        @Schema(description = "해지 완료 메시지", example = "구독이 해지되었습니다.")
+        private String message;
+    }
 }

--- a/src/main/java/com/example/speakOn/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/entity/Subscription.java
@@ -37,6 +37,15 @@ public class Subscription extends BaseEntity {
     // 결제 완료 시간
     private LocalDateTime approvedAt;
 
+    // 구독 해지 관련
+    @Column(name = "is_cancelled", nullable = false)
+    @Builder.Default
+    private Boolean isCancelled = false;
+
+    // 구독 해지 시간
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
     public static Subscription createSubscription(User user, String orderId, String orderName, Long amount, String paymentKey) {
         LocalDateTime now = LocalDateTime.now();
 
@@ -48,7 +57,14 @@ public class Subscription extends BaseEntity {
                 .paymentKey(paymentKey)
                 .approvedAt(now)
                 .expiredAt(now.plusDays(30)) // 만료기준 : +30일
+                .isCancelled(false)
                 .build();
     }
-}
 
+    // 구독 해지
+    public void cancel() {
+        this.isCancelled = true;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/example/speakOn/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/repository/SubscriptionRepository.java
@@ -13,8 +13,8 @@ import java.util.Optional;
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
     /**
-     * 유저의 유효한 구독 정보 조회 (현재 시간 기준 만료되지 않음)
+     * 유저의 유효한 구독 정보 조회 (현재 시간 기준 만료되지 않고, 해지되지 않음)
      */
-    @Query("SELECT s FROM Subscription s WHERE s.user.id = :userId AND s.expiredAt > :currentTime")
+    @Query("SELECT s FROM Subscription s WHERE s.user.id = :userId AND s.expiredAt > :currentTime AND s.isCancelled = false")
     Optional<Subscription> findActiveSubscriptionByUserId(@Param("userId") Long userId, @Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/com/example/speakOn/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/repository/SubscriptionRepository.java
@@ -13,8 +13,9 @@ import java.util.Optional;
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
     /**
-     * 유저의 유효한 구독 정보 조회 (현재 시간 기준 만료되지 않고, 해지되지 않음)
+     * 유저의 유효한 구독 정보 조회 (현재 시간 기준 만료되지 않음)
+     * 해지 여부와 무관하게 expiredAt으로만 판단
      */
-    @Query("SELECT s FROM Subscription s WHERE s.user.id = :userId AND s.expiredAt > :currentTime AND s.isCancelled = false")
+    @Query("SELECT s FROM Subscription s WHERE s.user.id = :userId AND s.expiredAt > :currentTime")
     Optional<Subscription> findActiveSubscriptionByUserId(@Param("userId") Long userId, @Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionService.java
@@ -7,4 +7,9 @@ public interface SubscriptionService {
 
     SubscriptionResponse.SubscriptionResponseDto successSubscription(Long userId, SubscriptionRequest.SubscriptionRequestDto request);
 
+    /**
+     * 구독 해지
+     */
+    SubscriptionResponse.CancelSubscriptionResponseDto cancelSubscription(Long userId);
+
 }

--- a/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionServiceImpl.java
@@ -81,13 +81,16 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                 .findActiveSubscriptionByUserId(userId, LocalDateTime.now())
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.SUBSCRIPTION_NOT_FOUND));
 
-        // 3. 구독 해지
+        // 3. 이미 해지된 구독 검증 (중복 해지 방어)
+        if (subscription.getIsCancelled()) {
+            throw new ErrorHandler(ErrorStatus.SUBSCRIPTION_ALREADY_CANCELLED);
+        }
+
+        // 4. 구독 해지
         subscription.cancel();
         subscriptionRepository.save(subscription);
 
-        log.info("구독 해지 완료 - userId: {}, subscriptionId: {}", userId, subscription.getId());
-
-        // 4. 응답 DTO 반환
+        // 5. 응답 DTO 반환
         return SubscriptionConverter.toCancelSubscriptionResponseDto(subscription);
 
     }

--- a/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/service/SubscriptionServiceImpl.java
@@ -15,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -63,6 +65,30 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
         // 6. 응답 DTO 반환
         return SubscriptionConverter.toSubscriptionResponseDto(savedSubscription);
+
+    }
+
+    @Transactional
+    @Override
+    public SubscriptionResponse.CancelSubscriptionResponseDto cancelSubscription(Long userId) {
+
+        // 1. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 활성 구독 조회
+        Subscription subscription = subscriptionRepository
+                .findActiveSubscriptionByUserId(userId, LocalDateTime.now())
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.SUBSCRIPTION_NOT_FOUND));
+
+        // 3. 구독 해지
+        subscription.cancel();
+        subscriptionRepository.save(subscription);
+
+        log.info("구독 해지 완료 - userId: {}, subscriptionId: {}", userId, subscription.getId());
+
+        // 4. 응답 DTO 반환
+        return SubscriptionConverter.toCancelSubscriptionResponseDto(subscription);
 
     }
 }

--- a/src/main/java/com/example/speakOn/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/example/speakOn/domain/user/converter/UserConverter.java
@@ -28,7 +28,8 @@ public class UserConverter {
     public static UserResponse.MyPageResponseDTO toMyPageResponseDTO(
             User user,
             Boolean isSubscribed,
-            LocalDateTime subscriptionExpiredAt) {
+            LocalDateTime subscriptionExpiredAt,
+            Boolean isSubscriptionCancelled) {
 
         return UserResponse.MyPageResponseDTO.builder()
                 .userId(user.getId())
@@ -40,6 +41,7 @@ public class UserConverter {
                 .createdAt(user.getCreatedAt())
                 .isSubscribed(isSubscribed)
                 .subscriptionExpiredAt(subscriptionExpiredAt)
+                .isSubscriptionCancelled(isSubscriptionCancelled)
                 .build();
     }
 

--- a/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
@@ -39,13 +39,13 @@ public class UserResponse {
         @Schema(description = "서비스 가입일", example = "2026-01-24T20:56:20.663238")
         private LocalDateTime createdAt;
 
-        @Schema(description = "구독 여부", example = "true")
+        @Schema(description = "구독 여부 (만료일 기준)", example = "true")
         private Boolean isSubscribed;
 
         @Schema(description = "구독 만료일", example = "2026-01-24T20:56:20.663238")
         private LocalDateTime subscriptionExpiredAt;
 
-        @Schema(description = "구독 해지 여부", example = "false")
+        @Schema(description = "구독 해지 여부 (만료일 이전에 해지한 경우 true)", example = "false")
         private Boolean isSubscriptionCancelled;
 
     }

--- a/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
@@ -45,6 +45,9 @@ public class UserResponse {
         @Schema(description = "구독 만료일", example = "2026-01-24T20:56:20.663238")
         private LocalDateTime subscriptionExpiredAt;
 
+        @Schema(description = "구독 해지 여부", example = "false")
+        private Boolean isSubscriptionCancelled;
+
     }
 
     @Builder

--- a/src/main/java/com/example/speakOn/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/user/service/UserQueryServiceImpl.java
@@ -46,7 +46,7 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .map(subscription -> subscription.getExpiredAt())
                 .orElse(null);
 
-        // 해지 여부
+        // 해지 여부: 활성 구독이 있으면서 해지된 경우
         Boolean isSubscriptionCancelled = activeSubscription
                 .map(subscription -> subscription.getIsCancelled())
                 .orElse(false);

--- a/src/main/java/com/example/speakOn/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/user/service/UserQueryServiceImpl.java
@@ -46,8 +46,13 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .map(subscription -> subscription.getExpiredAt())
                 .orElse(null);
 
+        // 해지 여부
+        Boolean isSubscriptionCancelled = activeSubscription
+                .map(subscription -> subscription.getIsCancelled())
+                .orElse(false);
+
         // 3. 응답 DTO 반환
-        return UserConverter.toMyPageResponseDTO(user, isSubscribed, subscriptionExpiredAt);
+        return UserConverter.toMyPageResponseDTO(user, isSubscribed, subscriptionExpiredAt, isSubscriptionCancelled);
     }
 
     // 온보딩 완료

--- a/src/main/java/com/example/speakOn/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/speakOn/global/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,7 @@ public enum ErrorStatus implements BaseCode {
 
     // 구독 관련 에러
     SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SUB404", "활성 구독이 없습니다."),
+    SUBSCRIPTION_ALREADY_CANCELLED(HttpStatus.CONFLICT, "SUB409", "이미 해지된 구독입니다."),
 
     // MyRole 관련 에러
     AVATAR_NOT_FOUND(HttpStatus.NOT_FOUND, "ROLE404", "존재하지 않는 아바타입니다."),

--- a/src/main/java/com/example/speakOn/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/speakOn/global/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,9 @@ public enum ErrorStatus implements BaseCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER401", "아이디와 일치하는 사용자가 없습니다."),
     PROFILE_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "USER400", "닉네임 또는 프로필 이미지 중 최소 1개를 입력해주세요."),
 
+    // 구독 관련 에러
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SUB404", "활성 구독이 없습니다."),
+
     // MyRole 관련 에러
     AVATAR_NOT_FOUND(HttpStatus.NOT_FOUND, "ROLE404", "존재하지 않는 아바타입니다."),
     MY_ROLE_ALREADY_EXISTS(HttpStatus.CONFLICT, "ROLE409", "이미 동일한 역할이 존재합니다."),


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #98 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
#### 구독 해지 기능 구현 & 마이페이지에 구독 해지 여부 조회 추가
- 엔드포인트 : `DELETE /api/subscription/cancel`
- 활성화 된 구독이 있을 때 해지 가능
- 중복 구독 해지 방지
- 구독 해지 안 함: `isSubscriptionCancelled = false`
- 구독 해지함: `isSubscriptionCancelled = true`
- 구독 없음: `isSubscriptionCancelled = false`

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="2324" height="1398" alt="image" src="https://github.com/user-attachments/assets/8004c080-10cc-42df-b3a5-5d88b0b2bc15" />

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 구독 취소 API: 사용자가 자신의 활성 구독을 취소할 수 있는 기능이 추가되었습니다.
  * 마이페이지에 구독 취소 여부 표시가 추가되었습니다.

* **개선 사항**
  * 구독 취소 시 취소 시각이 정확히 기록되어 응답에 포함됩니다.
  * 취소 관련 오류(활성 구독 없음, 이미 취소된 구독)에 대한 명확한 상태 코드 및 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->