### PR TITLE
[#111] ✨ Feat: 회원 탈퇴 기능 구현(Hard Delete ver.)

### DIFF
--- a/src/main/java/com/example/speakOn/domain/myReport/entity/MyReport.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/entity/MyReport.java
@@ -23,12 +23,10 @@ public class MyReport extends BaseEntity {
     @JoinColumn(name = "session_id", nullable = false, unique = true)
     private ConversationSession session;
 
-    // 대화 톤 (1:1, 양방향)
-    @OneToOne(mappedBy = "report", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "report", fetch = FetchType.LAZY)
     private ConversationTone conversationTone;
 
-    // 대화 교정 (1:N, 양방향)
-    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "report", fetch = FetchType.LAZY)
     @Builder.Default
     private List<ConversationCorrection> corrections = new ArrayList<>();
 

--- a/src/main/java/com/example/speakOn/domain/myReport/repository/MyReportRepository.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/repository/MyReportRepository.java
@@ -3,8 +3,18 @@ package com.example.speakOn.domain.myReport.repository;
 import com.example.speakOn.domain.myReport.entity.MyReport;
 import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MyReportRepository extends JpaRepository<MyReport, Long>, MyReportRepositoryCustom {
     MyReport findBySession(ConversationSession session);
     boolean existsBySessionId(Long sessionId);
+
+    /**
+     * 사용자의 모든 리포트 벌크 삭제 (회원 탈퇴 시)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MyReport mr WHERE mr.session.myRole.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/speakOn/domain/myRole/entity/MyRole.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/entity/MyRole.java
@@ -3,10 +3,14 @@ package com.example.speakOn.domain.myRole.entity;
 import com.example.speakOn.domain.avatar.entity.Avatar;
 import com.example.speakOn.domain.avatar.enums.SituationType;
 import com.example.speakOn.domain.myRole.enums.JobType;
+import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
 import com.example.speakOn.domain.user.entity.User;
 import com.example.speakOn.global.apiPayload.code.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -43,6 +47,10 @@ public class MyRole extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private boolean isActive = true;
+
+    @OneToMany(mappedBy = "myRole", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<ConversationSession> conversationSessions = new ArrayList<>();
 
     /**
      * 롤을 비활성화 (soft delete)

--- a/src/main/java/com/example/speakOn/domain/myRole/entity/MyRole.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/entity/MyRole.java
@@ -48,7 +48,7 @@ public class MyRole extends BaseEntity {
     @Builder.Default
     private boolean isActive = true;
 
-    @OneToMany(mappedBy = "myRole", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "myRole", fetch = FetchType.LAZY)
     @Builder.Default
     private List<ConversationSession> conversationSessions = new ArrayList<>();
 

--- a/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
+++ b/src/main/java/com/example/speakOn/domain/myRole/repository/MyRoleRepository.java
@@ -6,6 +6,9 @@ import com.example.speakOn.domain.myRole.entity.MyRole;
 import com.example.speakOn.domain.myRole.enums.JobType;
 import com.example.speakOn.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,4 +27,8 @@ public interface MyRoleRepository extends JpaRepository<MyRole, Long>, MyRoleRep
     // ID와 활성화 상태로 MyRole 조회 (soft delete 지원)
     Optional<MyRole> findByIdAndIsActiveTrue(Long id);
 
+    // 회원 탈퇴 시 롤 벌크삭제
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MyRole mr WHERE mr.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/entity/ConversationSession.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/entity/ConversationSession.java
@@ -47,11 +47,13 @@ public class ConversationSession extends BaseEntity {
     @Column(name = "ended_at")
     private LocalDateTime endedAt;
 
+    @OneToOne(mappedBy = "session", fetch = FetchType.LAZY)
+    private MyReport myReport;
+
     // 메인 질문 카운트 증가
     public void incrementQuestionCount() {
         this.currentQuestionCount++;
     }
-
 
     // 대화 종료 시 결과 데이터 업데이트
     public void completeSession(Integer totalTime, Integer sentenceCount, LocalDateTime endedAt) {
@@ -59,15 +61,10 @@ public class ConversationSession extends BaseEntity {
         this.totalTime = totalTime;
         this.sentenceCount = sentenceCount;
         this.endedAt = endedAt;
-
     }
 
     // 사용자 난이도 저장
     public void saveUserDifficulty(Integer userDifficulty) {
         this.userDifficulty = userDifficulty;
     }
-
-    // 리포트와의 1:1 양방향 매핑 추가
-    @OneToOne(mappedBy = "session", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private MyReport myReport;
 }

--- a/src/main/java/com/example/speakOn/domain/mySpeak/repository/ConversationSessionRepository.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/repository/ConversationSessionRepository.java
@@ -33,4 +33,14 @@ public class ConversationSessionRepository {
                 .findFirst();
     }
 
+    /**
+     * 사용자의 모든 대화 세션 벌크 삭제 (회원 탈퇴 시)
+     */
+    public void deleteAllByUserId(Long userId) {
+        em.createQuery(
+                "DELETE FROM ConversationSession cs WHERE cs.myRole.user.id = :userId"
+        ).setParameter("userId", userId)
+         .executeUpdate();
+    }
+
 }

--- a/src/main/java/com/example/speakOn/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/example/speakOn/domain/subscription/repository/SubscriptionRepository.java
@@ -2,6 +2,7 @@ package com.example.speakOn.domain.subscription.repository;
 
 import com.example.speakOn.domain.subscription.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -18,4 +19,11 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
      */
     @Query("SELECT s FROM Subscription s WHERE s.user.id = :userId AND s.expiredAt > :currentTime")
     Optional<Subscription> findActiveSubscriptionByUserId(@Param("userId") Long userId, @Param("currentTime") LocalDateTime currentTime);
+
+    /**
+     * 사용자의 모든 구독 벌크 삭제 (회원 탈퇴 시)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Subscription s WHERE s.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/speakOn/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/speakOn/domain/user/controller/UserController.java
@@ -99,4 +99,26 @@ public class UserController {
 
         return ApiResponse.onSuccess(response);
     }
+
+    // 회원 탈퇴
+    @Operation(
+            summary = "회원 탈퇴 API",
+            description = "사용자 계정을 완전히 삭제합니다. (Hard Delete)"
+    )
+    @ApiSuccessCodeExample(resultClass = UserResponse.WithdrawResponseDTO.class)
+    @ApiErrorCodeExamples({
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "USER_NOT_FOUND"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_UNAUTHORIZED"),
+            @ApiErrorCodeExample(value = ErrorStatus.class, name = "_INTERNAL_SERVER_ERROR")
+    })
+    @DeleteMapping("/withdraw")
+    public ApiResponse<UserResponse.WithdrawResponseDTO> withdrawUser() {
+
+        Long userId = authUtil.getCurrentUserId();
+        log.info("회원 탈퇴 요청 - userId: {}", userId);
+
+        UserResponse.WithdrawResponseDTO response = userCommandService.withdrawUser(userId);
+
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/speakOn/domain/user/dto/UserResponse.java
@@ -69,4 +69,18 @@ public class UserResponse {
         @Schema(description = "수정 완료 메시지", example = "프로필이 성공적으로 수정되었습니다.")
         private String message;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "회원 탈퇴 응답 DTO")
+    public static class WithdrawResponseDTO {
+
+        @Schema(description = "탈퇴된 유저 ID", example = "1")
+        private Long userId;
+
+        @Schema(description = "탈퇴 완료 메시지", example = "회원 탈퇴가 완료되었습니다.")
+        private String message;
+    }
 }

--- a/src/main/java/com/example/speakOn/domain/user/entity/User.java
+++ b/src/main/java/com/example/speakOn/domain/user/entity/User.java
@@ -58,11 +58,11 @@ public class User extends BaseEntity {
     @Builder.Default
     private Integer totalLogViewCount = 0;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     @Builder.Default
     private List<MyRole> myRoles = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     @Builder.Default
     private List<Subscription> subscriptions = new ArrayList<>();
 

--- a/src/main/java/com/example/speakOn/domain/user/entity/User.java
+++ b/src/main/java/com/example/speakOn/domain/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.example.speakOn.domain.user.entity;
 
+import com.example.speakOn.domain.myRole.entity.MyRole;
+import com.example.speakOn.domain.subscription.entity.Subscription;
 import com.example.speakOn.domain.user.enums.Role;
 import com.example.speakOn.domain.user.enums.SocialType;
 import com.example.speakOn.global.apiPayload.code.BaseEntity;
@@ -9,6 +11,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "users", uniqueConstraints = {
@@ -53,11 +58,13 @@ public class User extends BaseEntity {
     @Builder.Default
     private Integer totalLogViewCount = 0;
 
-    // TODO: 프로필 정보 업데이트
-    public void update(String nickname) {
-        this.nickname = nickname;
-        this.profileImgUrl = profileImgUrl;
-    }
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<MyRole> myRoles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Subscription> subscriptions = new ArrayList<>();
 
     /**
      * 닉네임 수정

--- a/src/main/java/com/example/speakOn/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/example/speakOn/domain/user/service/UserCommandService.java
@@ -14,4 +14,9 @@ public interface UserCommandService {
             Long userId,
             UserRequest.UpdateProfileRequestDto request
     );
+
+    /**
+     * 회원 탈퇴 (Hard Delete)
+     */
+    UserResponse.WithdrawResponseDTO withdrawUser(Long userId);
 }

--- a/src/main/java/com/example/speakOn/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/example/speakOn/domain/user/service/UserCommandServiceImpl.java
@@ -1,5 +1,9 @@
 package com.example.speakOn.domain.user.service;
 
+import com.example.speakOn.domain.myReport.repository.MyReportRepository;
+import com.example.speakOn.domain.myRole.repository.MyRoleRepository;
+import com.example.speakOn.domain.mySpeak.repository.ConversationSessionRepository;
+import com.example.speakOn.domain.subscription.repository.SubscriptionRepository;
 import com.example.speakOn.domain.user.converter.UserConverter;
 import com.example.speakOn.domain.user.dto.UserRequest;
 import com.example.speakOn.domain.user.dto.UserResponse;
@@ -21,6 +25,10 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     private final UserRepository userRepository;
     private final S3Util s3Util;
+    private final MyRoleRepository myRoleRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final ConversationSessionRepository conversationSessionRepository;
+    private final MyReportRepository myReportRepository;
 
     @Override
     @Transactional
@@ -68,5 +76,32 @@ public class UserCommandServiceImpl implements UserCommandService {
                 updatedUser,
                 "프로필이 성공적으로 수정되었습니다."
         );
+    }
+
+    @Transactional
+    @Override
+    public UserResponse.WithdrawResponseDTO withdrawUser(Long userId) {
+
+        // 1. 사용자 존재 확인
+        if (!userRepository.existsById(userId)) {
+            throw new ErrorHandler(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        // 2. 벌크 삭제
+        myReportRepository.deleteAllByUserId(userId);
+        conversationSessionRepository.deleteAllByUserId(userId);
+        myRoleRepository.deleteAllByUserId(userId);
+        subscriptionRepository.deleteAllByUserId(userId);
+
+        // 3. 사용자 삭제
+        userRepository.deleteById(userId);
+
+        log.info("회원 탈퇴 완료 - userId: {}", userId);
+
+        // 4. 응답 DTO 반환
+        return UserResponse.WithdrawResponseDTO.builder()
+                .userId(userId)
+                .message("회원 탈퇴가 완료되었습니다.")
+                .build();
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #111 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
#### 회원 탈퇴 기능 구현
- 엔드포인트 :  `DELETE /api/user/withdraw`
- Hard Delete로 회원과 관련된 모든 데이터 삭제
#### 성능 최적화
- 모든 벌크 삭제 메서드를 회원 탈퇴 메서드에 통합
- 삭제 순서 최적화: MyReport → ConversationSession → MyRole → Subscription → User
- N+1 쿼리 문제 해결

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="398" height="724" alt="image" src="https://github.com/user-attachments/assets/f6b1be64-6103-44ea-80d6-3ba21db7b39c" />

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원 탈퇴 기능 추가 — 사용자가 계정을 완전 삭제할 수 있으며, 탈퇴 시 관련 데이터가 함께 안전하게 일괄 삭제됩니다.
  * 탈퇴 완료 시 확인 응답(사용자 ID 및 메시지)을 반환하여 삭제 결과를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->