### PR TITLE
[#120] ♻️ Refactor: 새로고침 시 중복 차감 수정 및 리포트 대화 로그 조회 로직 개선

### DIFF
--- a/src/main/java/com/example/speakOn/domain/myReport/controller/MyReportController.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/controller/MyReportController.java
@@ -45,16 +45,18 @@ public class MyReportController implements MyReportControllerDocs {
 
     @Override
     @GetMapping("/{reportId}")
-    public ApiResponse<MyReportResponseDTO.ReportDetailDTO> getReportDetail(@PathVariable(name = "reportId") Long reportId) {
+    public ApiResponse<MyReportResponseDTO.ReportDetailDTO> getReportDetail(@PathVariable(name = "reportId") Long reportId,
+                                                                            @RequestParam(name = "viewUUID") String viewUUID) {
         Long userId = authUtil.getCurrentUserId();
-        return ApiResponse.onSuccess(myReportService.getReportDetail(reportId, userId));
+        return ApiResponse.onSuccess(myReportService.getReportDetail(reportId, userId, viewUUID));
     }
 
     @Override
     @GetMapping("/{reportId}/logs")
-    public ApiResponse<MyReportResponseDTO.MessageLogListDTO> getConversationLogs(@PathVariable(name = "reportId") Long reportId) {
+    public ApiResponse<MyReportResponseDTO.MessageLogListDTO> getConversationLogs(@PathVariable(name = "reportId") Long reportId,
+                                                                                  @RequestParam(name = "viewUUID") String viewUUID) {
         Long userId = authUtil.getCurrentUserId();
-        return ApiResponse.onSuccess(myReportService.getConversationLogs(reportId, userId));
+        return ApiResponse.onSuccess(myReportService.getConversationLogs(reportId, userId, viewUUID));
     }
 
     @Override

--- a/src/main/java/com/example/speakOn/domain/myReport/converter/MyReportConverter.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/converter/MyReportConverter.java
@@ -61,7 +61,7 @@ public class MyReportConverter {
     }
 
     // 리포트 상세 조회
-    public static MyReportResponseDTO.ReportDetailDTO toReportDetailDTO(MyReport myReport, List<ConversationMessage> messages, Boolean isLogLocked) {
+    public static MyReportResponseDTO.ReportDetailDTO toReportDetailDTO(MyReport myReport, List<ConversationMessage> messages, Boolean isLogLocked, Integer usedLogViewCount) {
         ConversationSession session = myReport.getSession();
         MyRole myRole = (session != null) ? session.getMyRole() : null;
         Avatar avatar = (myRole != null) ? myRole.getAvatar() : null;
@@ -94,6 +94,8 @@ public class MyReportConverter {
                 .userReflection(myReport.getUserReflection())
                 .conversationLog(toMessageLogDTOList(messages))
                 .isLogLocked(isLogLocked)
+                .usedLogViewCount(usedLogViewCount)
+                .maxLogViewCount(5)
                 .build();
     }
 
@@ -136,7 +138,8 @@ public class MyReportConverter {
     }
 
     // 대화 로그 조회
-    public static MyReportResponseDTO.MessageLogListDTO toMessageLogListDTO(Long reportId, List<ConversationMessage> messages) {
+    public static MyReportResponseDTO.MessageLogListDTO toMessageLogListDTO(Long reportId, List<ConversationMessage> messages, Boolean isLogLocked,
+                                                                            Integer usedLogViewCount) {
         if (messages == null) {
             return MyReportResponseDTO.MessageLogListDTO.builder()
                     .reportId(reportId)
@@ -156,7 +159,10 @@ public class MyReportConverter {
         return MyReportResponseDTO.MessageLogListDTO.builder()
                 .reportId(reportId)
                 .messages(logList)
-                .totalMessageCount(logList.size())
+                .totalMessageCount(logList != null ? logList.size() : 0)
+                .isLogLocked(isLogLocked)
+                .usedLogViewCount(usedLogViewCount)
+                .maxLogViewCount(5)
                 .build();
     }
 

--- a/src/main/java/com/example/speakOn/domain/myReport/docs/MyReportControllerDocs.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/docs/MyReportControllerDocs.java
@@ -46,20 +46,34 @@ public interface MyReportControllerDocs {
             Pageable pageable);
 
     @Operation(summary = "리포트 상세 조회 API", description = "특정 리포트의 상세 데이터(AI 분석, 소감, 대화 로그)를 조회합니다.")
+    @Parameters({
+            @Parameter(name = "reportId", description = "리포트 ID", example = "1", required = true),
+            @Parameter(name = "viewUUID", description = "중복 차감 방지용 1회성 UUID (새로고침 시 유지, 재진입 시 갱신)", example = "550e8400-e29b-41d4-a716-446655440000", required = true)
+    })
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REPORT4041", description = "해당 ID의 리포트를 찾을 수 없습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REPORT4031", description = "본인의 리포트만 조회할 수 있습니다.")
     })
-    ApiResponse<MyReportResponseDTO.ReportDetailDTO> getReportDetail(@PathVariable(name = "reportId") Long reportId);
+    ApiResponse<MyReportResponseDTO.ReportDetailDTO> getReportDetail(
+            @PathVariable(name = "reportId") Long reportId,
+            @RequestParam(name = "viewUUID") String viewUUID
+    );
 
     @Operation(summary = "리포트 대화 로그 상세 조회 API", description = "특정 리포트의 전체 대화 내용을 시간순으로 조회합니다.")
+    @Parameters({
+            @Parameter(name = "reportId", description = "리포트 ID", example = "1", required = true),
+            @Parameter(name = "viewUUID", description = "중복 차감 방지용 1회성 UUID (새로고침 시 유지, 재진입 시 갱신)", example = "550e8400-e29b-41d4-a716-446655440000", required = true)
+    })
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REPORT4041", description = "존재하지 않는 리포트입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "REPORT4031", description = "해당 리포트에 접근할 권한이 없습니다.")
     })
-    ApiResponse<MyReportResponseDTO.MessageLogListDTO> getConversationLogs(@PathVariable(name = "reportId") Long reportId);
+    ApiResponse<MyReportResponseDTO.MessageLogListDTO> getConversationLogs(
+            @PathVariable(name = "reportId") Long reportId,
+            @RequestParam(name = "viewUUID") String viewUUID
+    );
 
     @Operation(summary = "사용자 소감 작성 및 난이도 수정 API", description = "리포트 상세 조회 후, 사용자가 소감을 작성하고 난이도를 수정할 때 사용합니다.")
     @ApiResponses({

--- a/src/main/java/com/example/speakOn/domain/myReport/dto/response/MyReportResponseDTO.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/dto/response/MyReportResponseDTO.java
@@ -83,8 +83,14 @@ public class MyReportResponseDTO {
         @Schema(description = "대화 로그")
         private List<MessageLogDTO> conversationLog;
 
-        @Schema(description = "대화 로그 잠금 여부 (true: 횟수 소진으로 미제공, false: 정상 제공)", example = "false")
+        @Schema(description = "대화 로그 잠금 여부 (true: 블러 처리 필요, false: 정상 노출)", example = "false")
         private Boolean isLogLocked;
+
+        @Schema(description = "현재 사용한 무료 조회 횟수", example = "3")
+        private Integer usedLogViewCount;
+
+        @Schema(description = "최대 무료 조회 횟수", example = "5")
+        private Integer maxLogViewCount;
     }
 
     @Builder
@@ -155,6 +161,15 @@ public class MyReportResponseDTO {
 
         @Schema(description = "대화 로그 목록")
         private List<MessageLogDTO> messages;
+
+        @Schema(description = "대화 로그 잠금 여부", example = "true")
+        private Boolean isLogLocked;
+
+        @Schema(description = "현재 사용한 무료 조회 횟수", example = "5")
+        private Integer usedLogViewCount;
+
+        @Schema(description = "최대 무료 조회 횟수", example = "5")
+        private Integer maxLogViewCount;
     }
 
     @Builder

--- a/src/main/java/com/example/speakOn/domain/myReport/entity/ReportViewHistory.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/entity/ReportViewHistory.java
@@ -11,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "report_view_history", indexes = {
-        @Index(name = "idx_view_history_deduplication", columnList = "report_id, user_id, view_uuid, unique = true")
+        @Index(name = "idx_view_history_deduplication", columnList = "report_id, user_id, view_uuid", unique = true)
 })
 public class ReportViewHistory extends BaseEntity {
 

--- a/src/main/java/com/example/speakOn/domain/myReport/entity/ReportViewHistory.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/entity/ReportViewHistory.java
@@ -1,0 +1,29 @@
+package com.example.speakOn.domain.myReport.entity;
+
+import com.example.speakOn.domain.user.entity.User;
+import com.example.speakOn.global.apiPayload.code.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "report_view_history", indexes = {
+        @Index(name = "idx_view_history_deduplication", columnList = "report_id, user_id, view_uuid")
+})
+public class ReportViewHistory extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private MyReport report;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 프론트엔드에서 생성한 1회용 조회 식별자
+    @Column(name = "view_uuid", nullable = false)
+    private String viewUUID;
+}

--- a/src/main/java/com/example/speakOn/domain/myReport/entity/ReportViewHistory.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/entity/ReportViewHistory.java
@@ -11,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "report_view_history", indexes = {
-        @Index(name = "idx_view_history_deduplication", columnList = "report_id, user_id, view_uuid")
+        @Index(name = "idx_view_history_deduplication", columnList = "report_id, user_id, view_uuid, unique = true")
 })
 public class ReportViewHistory extends BaseEntity {
 

--- a/src/main/java/com/example/speakOn/domain/myReport/repository/ReportViewHistoryRepository.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/repository/ReportViewHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.example.speakOn.domain.myReport.repository;
+
+import com.example.speakOn.domain.myReport.entity.MyReport;
+import com.example.speakOn.domain.myReport.entity.ReportViewHistory;
+import com.example.speakOn.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportViewHistoryRepository extends JpaRepository<ReportViewHistory, Long> {
+    boolean existsByReportAndUserAndViewUUID(MyReport report, User user, String viewUUID);
+}

--- a/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
@@ -1,5 +1,7 @@
 package com.example.speakOn.domain.myReport.service;
 
+import com.example.speakOn.domain.myReport.entity.ReportViewHistory;
+import com.example.speakOn.domain.myReport.repository.ReportViewHistoryRepository;
 import com.example.speakOn.domain.myReport.code.MyReportErrorCode;
 import com.example.speakOn.domain.myReport.converter.MyReportConverter;
 import com.example.speakOn.domain.myReport.dto.request.MyReportRequest;
@@ -52,6 +54,8 @@ public class MyReportService {
     private final ConversationCorrectionRepository correctionRepository;
     private final MyRoleRepository myRoleRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final ReportViewHistoryRepository reportViewHistoryRepository;
+    private final int MAX_FREE_VIEW_COUNT = 5;
 
     private User findUser(Long userId) {
         return userRepository.findById(userId)
@@ -66,56 +70,81 @@ public class MyReportService {
 
         Slice<MyReport> reports = myReportRepository.findAllByUserAndFilters(user, filter, pageable);
 
-        // Slice를 Response DTO로 변환하여 반환
         return MyReportConverter.toReportSummaryListDTOFromSlice(reports);
     }
 
     /**
      * 리포트 상세 조회
+     *
+     * @param reportId 조회할 리포트의 ID
+     * @param userId 현재 로그인한 유저의 ID
+     * @param viewUUID 중복 차감 방지용 식별자 (새로고침 시 유지, 재진입 시 갱신)
+     * @return 리포트 상세 정보 DTO
      */
     @Transactional
-    public MyReportResponseDTO.ReportDetailDTO getReportDetail(Long reportId, Long userId) {
+    public MyReportResponseDTO.ReportDetailDTO getReportDetail(Long reportId, Long userId, String viewUUID) {
         User user = findUser(userId);
 
         MyReport report = myReportRepository.findReportWithAllDetails(reportId)
                 .orElseThrow(() -> new MyReportException(MyReportErrorCode.REPORT_NOT_FOUND));
 
-
         validateReportOwner(report, user);
 
-        // 1. 구독 여부 확인
+        // 구독 여부 확인
         boolean isSubscribed = subscriptionRepository
                 .findActiveSubscriptionByUserId(userId, LocalDateTime.now())
                 .isPresent();
 
-        // 2. 로그 열람 가능 여부 체크
-        boolean canViewLog = user.canViewLog(isSubscribed);
+        boolean isLogLocked = true;
 
+        // 이미 이 viewUUID로 차감된 기록이 있는지 확인 (새로고침인지 체크)
+        boolean isRefreshedRequest = reportViewHistoryRepository
+                .existsByReportAndUserAndViewUUID(report, user, viewUUID);
+
+        // 잠금 해제 기준
+        if (isSubscribed) {
+            // Case A: 구독자 -> 무조건 해제
+            isLogLocked = false;
+        } else if (isRefreshedRequest) {
+            // Case B: 새로고침 -> 이미 차감했으므로 해제
+            isLogLocked = false;
+        } else if (user.getTotalLogViewCount() < MAX_FREE_VIEW_COUNT) {
+            // Case C: 비구독자 & 새 요청 & 횟수 남음 -> 차감 후 해제
+            user.incrementLogViewCount(); // DB update
+
+            ReportViewHistory history = ReportViewHistory.builder()
+                    .report(report)
+                    .user(user)
+                    .viewUUID(viewUUID)
+                    .build();
+            reportViewHistoryRepository.save(history);
+
+            isLogLocked = false;
+        }
+        // Case D: 비구독자 & 새 요청 & 횟수 없음 -> isLogLocked = true 유지
+
+        // (잠금 해제된 경우) 로그 데이터 조회
         List<ConversationMessage> messages = List.of();
-        boolean isLogLocked = true; // 기본값: 잠금
-
-        // 3. 열람 가능하면 -> 데이터 조회 및 카운트 증가
-        if (canViewLog) {
+        if (!isLogLocked) {
             ConversationSession session = report.getSession();
             if (session != null) {
                 messages = messageRepository.findAllBySessionOrderByCreatedAtAsc(session);
             }
-
-            // 구독자가 아니면 조회수 증가
-            if (!isSubscribed) {
-                user.incrementLogViewCount();
-            }
-            isLogLocked = false; // 잠금 해제
         }
 
-        // 4. 변환기에 isLogLocked 전달
-        return MyReportConverter.toReportDetailDTO(report, messages, isLogLocked);
+        return MyReportConverter.toReportDetailDTO(
+                report,
+                messages,
+                isLogLocked,
+                user.getTotalLogViewCount()
+        );
     }
 
     /**
      * 대화 로그 상세 조회
      */
-    public MyReportResponseDTO.MessageLogListDTO getConversationLogs(Long reportId, Long userId) {
+    @Transactional
+    public MyReportResponseDTO.MessageLogListDTO getConversationLogs(Long reportId, Long userId, String viewUUID) {
         User user = findUser(userId);
         MyReport report = myReportRepository.findById(reportId)
                 .orElseThrow(() -> new MyReportException(MyReportErrorCode.REPORT_NOT_FOUND));
@@ -126,22 +155,41 @@ public class MyReportService {
                 .findActiveSubscriptionByUserId(userId, LocalDateTime.now())
                 .isPresent();
 
-        // 5회 이상이면 예외 발생
-        if (!user.canViewLog(isSubscribed)) {
-            throw new MyReportException(MyReportErrorCode.REPORT_VIEW_LIMIT_EXCEEDED);
-        }
+        boolean isLogLocked = true;
 
-        // (비구독자 경우) 조회 성공 시 카운트 증가
-        if (!isSubscribed) {
+        // 새로고침 체크
+        boolean isRefreshedRequest = reportViewHistoryRepository
+                .existsByReportAndUserAndViewUUID(report, user, viewUUID);
+
+        if (isSubscribed || isRefreshedRequest) {
+            isLogLocked = false;
+        } else if (user.getTotalLogViewCount() < MAX_FREE_VIEW_COUNT) {
             user.incrementLogViewCount();
+
+            ReportViewHistory history = ReportViewHistory.builder()
+                    .report(report)
+                    .user(user)
+                    .viewUUID(viewUUID)
+                    .build();
+            reportViewHistoryRepository.save(history);
+
+            isLogLocked = false;
         }
 
-        ConversationSession session = report.getSession();
-        List<ConversationMessage> messages = (session != null)
-                ? messageRepository.findAllBySessionOrderByCreatedAtAsc(session)
-                : List.of();
+        List<ConversationMessage> messages = List.of();
+        if (!isLogLocked) {
+            ConversationSession session = report.getSession();
+            messages = (session != null)
+                    ? messageRepository.findAllBySessionOrderByCreatedAtAsc(session)
+                    : List.of();
+        }
 
-        return MyReportConverter.toMessageLogListDTO(reportId, messages);
+        return MyReportConverter.toMessageLogListDTO(
+                reportId,
+                messages,
+                isLogLocked,
+                user.getTotalLogViewCount()
+        );
     }
 
     /**

--- a/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Pageable;
@@ -97,31 +98,29 @@ public class MyReportService {
 
         boolean isLogLocked = true;
 
-        // 이미 이 viewUUID로 차감된 기록이 있는지 확인 (새로고침인지 체크)
-        boolean isRefreshedRequest = reportViewHistoryRepository
+        boolean alreadyPaid = reportViewHistoryRepository
                 .existsByReportAndUserAndViewUUID(report, user, viewUUID);
 
-        // 잠금 해제 기준
-        if (isSubscribed) {
-            // Case A: 구독자 -> 무조건 해제
-            isLogLocked = false;
-        } else if (isRefreshedRequest) {
-            // Case B: 새로고침 -> 이미 차감했으므로 해제
+        if (isSubscribed || alreadyPaid) {
             isLogLocked = false;
         } else if (user.getTotalLogViewCount() < MAX_FREE_VIEW_COUNT) {
-            // Case C: 비구독자 & 새 요청 & 횟수 남음 -> 차감 후 해제
-            user.incrementLogViewCount(); // DB update
+            try {
+                ReportViewHistory history = ReportViewHistory.builder()
+                        .report(report)
+                        .user(user)
+                        .viewUUID(viewUUID)
+                        .build();
 
-            ReportViewHistory history = ReportViewHistory.builder()
-                    .report(report)
-                    .user(user)
-                    .viewUUID(viewUUID)
-                    .build();
-            reportViewHistoryRepository.save(history);
+                reportViewHistoryRepository.saveAndFlush(history);
 
-            isLogLocked = false;
+                user.incrementLogViewCount();
+                isLogLocked = false;
+
+            } catch (DataIntegrityViolationException e) {
+                log.warn("Concurrent report view detected for UUID: {}", viewUUID);
+                isLogLocked = false;
+            }
         }
-        // Case D: 비구독자 & 새 요청 & 횟수 없음 -> isLogLocked = true 유지
 
         // (잠금 해제된 경우) 로그 데이터 조회
         List<ConversationMessage> messages = List.of();

--- a/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
@@ -1,6 +1,7 @@
 package com.example.speakOn.domain.myReport.service;
 
 import com.example.speakOn.domain.myReport.entity.ReportViewHistory;
+import com.example.speakOn.domain.myReport.service.ReportViewHistoryService;
 import com.example.speakOn.domain.myReport.repository.ReportViewHistoryRepository;
 import com.example.speakOn.domain.myReport.code.MyReportErrorCode;
 import com.example.speakOn.domain.myReport.converter.MyReportConverter;
@@ -55,6 +56,7 @@ public class MyReportService {
     private final ConversationCorrectionRepository correctionRepository;
     private final MyRoleRepository myRoleRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final ReportViewHistoryService reportViewHistoryService;
     private final ReportViewHistoryRepository reportViewHistoryRepository;
     private final int MAX_FREE_VIEW_COUNT = 5;
 
@@ -111,7 +113,7 @@ public class MyReportService {
                         .viewUUID(viewUUID)
                         .build();
 
-                reportViewHistoryRepository.saveAndFlush(history);
+                reportViewHistoryService.trySaveHistory(history);
 
                 user.incrementLogViewCount();
                 isLogLocked = false;
@@ -163,16 +165,20 @@ public class MyReportService {
         if (isSubscribed || isRefreshedRequest) {
             isLogLocked = false;
         } else if (user.getTotalLogViewCount() < MAX_FREE_VIEW_COUNT) {
-            user.incrementLogViewCount();
-
-            ReportViewHistory history = ReportViewHistory.builder()
-                    .report(report)
-                    .user(user)
-                    .viewUUID(viewUUID)
-                    .build();
-            reportViewHistoryRepository.save(history);
-
-            isLogLocked = false;
+            try {
+                ReportViewHistory history = ReportViewHistory.builder()
+                        .report(report)
+                        .user(user)
+                        .viewUUID(viewUUID)
+                        .build();
+                reportViewHistoryService.trySaveHistory(history);
+                
+                user.incrementLogViewCount();
+                isLogLocked = false;
+            } catch (DataIntegrityViolationException e) {
+                log.warn("Concurrent conversation log view detected for UUID: {}", viewUUID);
+                isLogLocked = false;
+            }
         }
 
         List<ConversationMessage> messages = List.of();

--- a/src/main/java/com/example/speakOn/domain/myReport/service/ReportViewHistoryService.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/service/ReportViewHistoryService.java
@@ -1,0 +1,20 @@
+package com.example.speakOn.domain.myReport.service;
+
+import com.example.speakOn.domain.myReport.entity.ReportViewHistory;
+import com.example.speakOn.domain.myReport.repository.ReportViewHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportViewHistoryService {
+
+    private final ReportViewHistoryRepository reportViewHistoryRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void trySaveHistory(ReportViewHistory history) {
+        reportViewHistoryRepository.saveAndFlush(history);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #120 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 리포트 상세 및 대화 로그 조회 시 무료 횟수 차감 로직을 개선
프론트엔드 요청 사항인 블러 처리용 데이터 반환, 현재 조회수 표시, 새로고침 시 차감 방지 기능 구현

### 조회 로직 변경 (MyReportService)
기존: 횟수 소진 시 throw new ErrorHandler(403)
변경: 횟수 소진 시 isLogLocked: true를 포함한 정상 응답(200 OK) 반환 (내용은 빈 리스트)

### 중복 차감 방지 (Idempotency Key 패턴 적용)
Entity 추가: ReportViewHistory (누가, 어떤 리포트를, 어떤 UUID로 봤는지 기록)
로직: viewUUID를 파라미터로 받아 이미 기록된 UUID라면(새로고침) 횟수를 차감하지 않음

### DTO 수정 (MyReportResponseDTO)
isLogLocked, usedLogViewCount, maxLogViewCount 필드 추가

### Controller / Docs 수정
getReportDetail, getConversationLogs 메서드에 필수 파라미터 @RequestParam String viewUUID 추가

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [ ] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 보고서 조회 이력(viewUUID 기반) 추적 및 저장 기능 추가
  * 무료 사용자 대상 조회 횟수 월 5회 제한 및 조회 횟수 집계 도입
  * 보고서 상세 및 대화 로그 응답에 사용한 조회수, 최대 조회수, 잠금 여부 노출

* **문서**
  * 관련 엔드포인트에 viewUUID 요청 파라미터 설명 추가 및 API 문서 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->