### PR TITLE
♻️ Refactor: MyReport 최적화 및 필터링 강화

### DIFF
--- a/src/main/java/com/example/speakOn/domain/myReport/repository/MyReportRepository.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/repository/MyReportRepository.java
@@ -4,8 +4,10 @@ import com.example.speakOn.domain.myReport.entity.MyReport;
 import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 public interface MyReportRepository extends JpaRepository<MyReport, Long>, MyReportRepositoryCustom {
-    MyReport findBySession(ConversationSession session);
+    Optional<MyReport> findBySession(ConversationSession session);
     boolean existsBySessionId(Long sessionId);
 }

--- a/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
@@ -16,6 +16,7 @@ import com.example.speakOn.domain.myRole.entity.MyRole;
 import com.example.speakOn.domain.myRole.repository.MyRoleRepository;
 import com.example.speakOn.domain.mySpeak.entity.ConversationMessage;
 import com.example.speakOn.domain.mySpeak.entity.ConversationSession;
+import com.example.speakOn.domain.mySpeak.enums.SenderRole;
 import com.example.speakOn.domain.mySpeak.repository.ConversationMessageRepository;
 import com.example.speakOn.domain.mySpeak.repository.ConversationSessionRepository;
 import com.example.speakOn.domain.subscription.repository.SubscriptionRepository;
@@ -232,51 +233,53 @@ public class MyReportService {
     @Transactional
     public MyReportResponseDTO.ReportDetailDTO generateReport(Long sessionId) {
 
-        ConversationSession session = sessionRepository.findById(sessionId);
-        if (session == null) {
-            throw new GeneralException(ErrorStatus.SESSION_NOT_FOUND);
-        }
+        ConversationSession session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.SESSION_NOT_FOUND));
 
-        List<ConversationMessage> messages = messageRepository.findAllBySessionOrderByCreatedAtAsc(session);
-        if (messages.isEmpty()) {
+        List<ConversationMessage> allmessages = messageRepository.findAllBySessionOrderByCreatedAtAsc(session);
+        boolean hasUserMessage = allmessages.stream()
+                .anyMatch(m -> SenderRole.USER.equals(m.getSenderRole()));
+
+        if (!hasUserMessage) {
+            log.warn("사용자 답변이 없는 세션에 대한 분석 시도 차단 - sessionId: {}", sessionId);
             throw new GeneralException(ErrorStatus.CONVERSATION_NOT_FOUND);
         }
 
-        Long myRoleId = session.getMyRole().getId();
-        MyRole myRole = myRoleRepository.findByIdAndIsActiveTrue(myRoleId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MY_ROLE_NOT_FOUND));
+        MyReport myReport = myReportRepository.findBySession(session)
+                .orElseGet(() -> {
 
-        MyReportResponseDTO.AiInsightCardDTO aiInsightCard = getAiInsight(messages, myRole);
+                    MyRole myRole = session.getMyRole();
+                    MyReportResponseDTO.AiInsightCardDTO aiInsight = getAiInsight(allmessages, myRole);
 
-        // session.getMyReport()가 없으면 새로 생성, 있으면 업데이트
-        MyReport myReport = session.getMyReport();
-        if (myReport == null) {
-            myReport = MyReport.builder()
-                    .session(session)
-                    .aiSummary(aiInsightCard.getAiSummary())
-                    .aiReason(aiInsightCard.getAiReason())
-                    .difficulty(session.getUserDifficulty())
-                    .build();
-            myReportRepository.save(myReport);
-        }
+                    MyReport newReport = MyReport.builder()
+                            .session(session)
+                            .aiSummary(aiInsight.getAiSummary())
+                            .aiReason(aiInsight.getAiReason())
+                            .difficulty(session.getUserDifficulty())
+                            .build();
 
-        MyReport finalReport = myReport;
-        List<ConversationCorrection> corrections = aiInsightCard.getCorrections().stream()
-                .map(dto -> ConversationCorrection.builder()
-                        .report(finalReport)
-                        .originalContent(dto.getOriginal())
-                        .correctedContent(dto.getCorrected())
-                        .correctionReason(dto.getReason())
-                        .build())
-                .collect(Collectors.toList());
+                    MyReport savedReport = myReportRepository.save(newReport);
 
-        correctionRepository.saveAll(corrections);
+                    List<ConversationCorrection> corrections = aiInsight.getCorrections().stream()
+                            .map(dto -> ConversationCorrection.builder()
+                                    .report(savedReport)
+                                    .originalContent(dto.getOriginal())
+                                    .correctedContent(dto.getCorrected())
+                                    .correctionReason(dto.getReason())
+                                    .build())
+                            .collect(Collectors.toList());
+                    correctionRepository.saveAll(corrections);
 
-        // 4. 최종 DTO 조립
+                    return savedReport;
+                });
+
+        // 3. 최종 DTO 조립 시 필요한 메시지 재조회
+        List<ConversationMessage> messages = messageRepository.findAllBySessionOrderByCreatedAtAsc(session);
+
         return MyReportResponseDTO.ReportDetailDTO.builder()
-                .reportId(myReport.getId()) // 저장된 리포트 ID 사용
-                .sessionSummary(buildSessionSummary(session, messages))
-                .aiInsightCard(aiInsightCard)
+                .reportId(myReport.getId())
+                .sessionSummary(buildSessionSummary(session, myReport))
+                .aiInsightCard(getAiInsightDTO(myReport))
                 .userReflection(myReport.getUserReflection())
                 .conversationLog(buildMessageLogs(messages))
                 .build();
@@ -293,42 +296,69 @@ public class MyReportService {
         String aiJsonResponse = aiAnalysisService.getAnalysisResult(transcript, myRole);
 
         try {
-            String cleaned = aiJsonResponse.replaceAll("(?s)```(?:json)?\\s*|```", "").trim();
-            int start = cleaned.indexOf("{");
-            int end = cleaned.lastIndexOf("}");
-
-            if (start != -1 && end != -1) {
-                cleaned = cleaned.substring(start, end + 1);
-            }
-
+            String cleaned = extractJson(aiJsonResponse);
             MyReportResponseDTO.AiInsightCardDTO result = objectMapper.readValue(cleaned, MyReportResponseDTO.AiInsightCardDTO.class);
 
             if (result.getCorrections() != null) {
-                result.getCorrections().removeIf(c ->
-                        messages.stream().anyMatch(m ->
-                                "AI".equals(m.getSenderRole().toString()) &&
-                                        m.getContent().trim().equals(c.getOriginal().trim())
-                        )
+                List<String> userContents = messages.stream()
+                        .filter(m -> "USER".equals(m.getSenderRole().name()))
+                        .map(m -> m.getContent().trim())
+                        .collect(Collectors.toList());
+
+                // 교정 제안 중 원문이 사용자 대화 목록에 없는 경우 삭제
+                result.getCorrections().removeIf(c -> {
+                            String originalTrimmed = c.getOriginal().trim();
+                            return userContents.stream().noneMatch(content -> content.equals(originalTrimmed));
+                        }
                 );
             }
-
             return result;
         } catch (JsonProcessingException e) {
             log.error("AI JSON Parsing Failed. Raw: {}", aiJsonResponse);
             throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
         }
+        }
+
+    private String extractJson(String raw) {
+        int start = raw.indexOf("{");
+        int end = raw.lastIndexOf("}");
+        if (start == -1 || end == -1) {
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+        return raw.substring(start, end + 1);
     }
+
+    /**
+     * DB에 저장된 리포트 엔티티를 바탕으로 AI 인사이트 DTO를 생성합니다.
+     */
+    private MyReportResponseDTO.AiInsightCardDTO getAiInsightDTO(MyReport myReport) {
+        // 1. 리포트에 저장된 교정 리스트를 DTO 리스트로 변환
+        List<MyReportResponseDTO.CorrectionDTO> correctionDTOs = myReport.getCorrections().stream()
+                .map(c -> MyReportResponseDTO.CorrectionDTO.builder()
+                        .original(c.getOriginalContent())
+                        .corrected(c.getCorrectedContent())
+                        .reason(c.getCorrectionReason())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 2. 최종 카드 DTO 조립
+        return MyReportResponseDTO.AiInsightCardDTO.builder()
+                .aiSummary(myReport.getAiSummary())
+                .aiReason(myReport.getAiReason())
+                .corrections(correctionDTOs)
+                .build();
+    }
+
 
     /**
      * 세션 요약 정보 조립 (중복 빌더 제거 및 MyRole 참조 최적화)
      */
-    private MyReportResponseDTO.SessionSummaryDTO buildSessionSummary(ConversationSession session, List<ConversationMessage> messages) {
+    private MyReportResponseDTO.SessionSummaryDTO buildSessionSummary(ConversationSession session, MyReport myReport) {
         LocalTime totalTime = (session.getTotalTime() != null)
                 ? LocalTime.ofSecondOfDay(session.getTotalTime())
                 : LocalTime.MIDNIGHT;
 
         MyRole myRole = session.getMyRole();
-        MyReport myReport = session.getMyReport();
 
         return MyReportResponseDTO.SessionSummaryDTO.builder()
                 .avatarName(myRole.getAvatar().getName())

--- a/src/main/java/com/example/speakOn/domain/mySpeak/entity/ConversationSession.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/entity/ConversationSession.java
@@ -54,8 +54,8 @@ public class ConversationSession extends BaseEntity {
     @Builder.Default
     private List<ConversationMessage> messages = new ArrayList<>();
 
-    @OneToOne(mappedBy = "session", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private MyReport myReport;
+//    @OneToOne(mappedBy = "session", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//    private MyReport myReport;
 
     @OneToOne(mappedBy = "session", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private AiConversationContext aiConversationContext;

--- a/src/main/java/com/example/speakOn/domain/mySpeak/repository/ConversationSessionRepository.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/repository/ConversationSessionRepository.java
@@ -17,8 +17,15 @@ public class ConversationSessionRepository {
         em.persist(session);
     }
 
-    public ConversationSession findById(Long sessionId) {
-        return em.find(ConversationSession.class, sessionId);
+    public Optional<ConversationSession> findById(Long sessionId) {
+        return em.createQuery(
+                        "select s from ConversationSession s " +
+                                "join fetch s.myRole r " +        // 세션과 연결된 역할 가져오기
+                                "join fetch r.avatar a " +      // 역할과 연결된 아바타까지 한 번에!
+                                "where s.id = :sessionId", ConversationSession.class)
+                .setParameter("sessionId", sessionId)
+                .getResultStream()
+                .findFirst();
     }
 
     public Optional<ConversationSession> findByIdWithAll(Long sessionId) {

--- a/src/main/java/com/example/speakOn/domain/mySpeak/service/MySpeakService.java
+++ b/src/main/java/com/example/speakOn/domain/mySpeak/service/MySpeakService.java
@@ -106,11 +106,10 @@ public class MySpeakService {
 
             // 저장
             conversationSessionRepository.save(session);
-            ConversationSession saved = conversationSessionRepository.findById(session.getId());
 
-            log.info("대화 세션 생성 완료 - sessionId: {}, myRole: {}", saved.getId(), myRole.getJob());
+            log.info("대화 세션 생성 완료 - sessionId: {}, myRole: {}", session.getId(), myRole.getJob());
 
-            return saved.getId();
+            return session.getId();
 
         }catch (MySpeakException e) {
             log.error("MySpeakException 발생 - myRoleId: {}", request.getMyRoleId(), e);
@@ -239,10 +238,8 @@ public class MySpeakService {
     @Transactional
     public void saveUserDifficulty(Long sessionId, UserDifficultyRequest request) {
         // 세션 조회
-        ConversationSession session = conversationSessionRepository.findById(sessionId);
-        if (session == null) {
-            throw new MySpeakException(MySpeakErrorCode.SESSION_NOT_FOUND);
-        }
+        ConversationSession session = conversationSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new MySpeakException(MySpeakErrorCode.SESSION_NOT_FOUND));
 
         session.saveUserDifficulty(request.getUserDifficulty());
     }


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> #123 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 성능 최적화: Fetch Join 및 단방향 매핑
-  ConversationSession 조회 시 MyRole, Avatar를 Fetch Join으로 한 번에 가져오도록 수정했습니다.
-  세션과 리포트 사이의 양방향 관계를 제거하고 단방향으로 변경했습니다.
- 세션 조회 시 리포트와 컨텍스트를 불필요하게 따라 조회하던  쿼리를 제거하여 최적화했습니다.
- 필터링:
- 사용자(USER) 발화가 없는 세션의 경우 리포트 생성을 차단하는 검증 로직을 추가

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  ConversationSessionRepository에 있던 findById 반환 타입을 Optional<T>로 수정하였습니다.

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [x] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="1402" height="383" alt="스크린샷 2026-02-11 오후 9 48 56" src="https://github.com/user-attachments/assets/9d0d20bb-3e24-4dbd-9976-f8649cd44032" />


## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>

