### PR TITLE
[#126] Fix: 회원 탈퇴 시 리포트 조회 기록 미삭제로 인한 에러 해결

### DIFF
--- a/src/main/java/com/example/speakOn/domain/myReport/entity/MyReport.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/entity/MyReport.java
@@ -30,6 +30,10 @@ public class MyReport extends BaseEntity {
     @Builder.Default
     private List<ConversationCorrection> corrections = new ArrayList<>();
 
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ReportViewHistory> viewHistories = new ArrayList<>();
+
     // 사용자 소감
     @Column(name = "user_reflection", length = 120)
     private String userReflection;

--- a/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
@@ -172,7 +172,7 @@ public class MyReportService {
                         .viewUUID(viewUUID)
                         .build();
                 reportViewHistoryService.trySaveHistory(history);
-                
+
                 user.incrementLogViewCount();
                 isLogLocked = false;
             } catch (DataIntegrityViolationException e) {

--- a/src/main/java/com/example/speakOn/domain/user/entity/User.java
+++ b/src/main/java/com/example/speakOn/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.speakOn.domain.user.entity;
 
+import com.example.speakOn.domain.myReport.entity.ReportViewHistory;
 import com.example.speakOn.domain.myRole.entity.MyRole;
 import com.example.speakOn.domain.subscription.entity.Subscription;
 import com.example.speakOn.domain.user.enums.Role;
@@ -65,6 +66,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Subscription> subscriptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<ReportViewHistory> reportViewHistories = new ArrayList<>();
 
     /**
      * 닉네임 수정


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #126 
## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
회원 탈퇴 기능 실행 시 users 테이블의 데이터 삭제가 report_view_history 테이블의 FK 제약 조건으로 인해 실패하는 버그를 수정했습니다.

- User Entity: reportViewHistories 리스트를 추가하고 CascadeType.ALL, orphanRemoval = true 설정을 적용하여 유저 삭제 시 관련 조회 기록도 함께 삭제되도록 수정했습니다.
- MyReport Entity: 리포트 삭제 시에도 동일한 문제가 발생할 수 있기에 viewHistories 리스트를 추가하고 동일하게 Cascade 설정을 적용했습니다.

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [ ] 컨벤션을 지키고 있나요?
- [ ] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 보고서 조회 기록 추적 기능 추가

* **기타**
  * 코드 정리 및 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->