### PR TITLE
[Refactor] : Myreport 로직 수정

### DIFF
--- a/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
+++ b/src/main/java/com/example/speakOn/domain/myReport/service/MyReportService.java
@@ -38,6 +38,7 @@ import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -232,24 +233,27 @@ public class MyReportService {
      */
     @Transactional
     public MyReportResponseDTO.ReportDetailDTO generateReport(Long sessionId) {
-
         ConversationSession session = sessionRepository.findById(sessionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.SESSION_NOT_FOUND));
 
-        List<ConversationMessage> allmessages = messageRepository.findAllBySessionOrderByCreatedAtAsc(session);
-        boolean hasUserMessage = allmessages.stream()
+        List<ConversationMessage> messages = messageRepository.findAllBySessionOrderByCreatedAtAsc(session);
+        boolean hasUserMessage = messages.stream()
                 .anyMatch(m -> SenderRole.USER.equals(m.getSenderRole()));
 
-        if (!hasUserMessage) {
-            log.warn("사용자 답변이 없는 세션에 대한 분석 시도 차단 - sessionId: {}", sessionId);
-            throw new GeneralException(ErrorStatus.CONVERSATION_NOT_FOUND);
-        }
 
         MyReport myReport = myReportRepository.findBySession(session)
                 .orElseGet(() -> {
+                    MyReportResponseDTO.AiInsightCardDTO aiInsight;
 
-                    MyRole myRole = session.getMyRole();
-                    MyReportResponseDTO.AiInsightCardDTO aiInsight = getAiInsight(allmessages, myRole);
+                    if (hasUserMessage) {
+                        aiInsight = getAiInsight(messages, session.getMyRole());
+                    } else {
+                        aiInsight = MyReportResponseDTO.AiInsightCardDTO.builder()
+                                .aiSummary("진행된 대화가 없어 AI 분석이 수행되지 않았습니다.")
+                                .aiReason(List.of("사용자 답변이 감지되지 않았습니다. 아바타와 대화를 나눠보세요!"))
+                                .corrections(Collections.emptyList())
+                                .build();
+                    }
 
                     MyReport newReport = MyReport.builder()
                             .session(session)
@@ -260,31 +264,26 @@ public class MyReportService {
 
                     MyReport savedReport = myReportRepository.save(newReport);
 
-                    List<ConversationCorrection> corrections = aiInsight.getCorrections().stream()
-                            .map(dto -> ConversationCorrection.builder()
-                                    .report(savedReport)
-                                    .originalContent(dto.getOriginal())
-                                    .correctedContent(dto.getCorrected())
-                                    .correctionReason(dto.getReason())
-                                    .build())
-                            .collect(Collectors.toList());
-                    correctionRepository.saveAll(corrections);
+                    if (hasUserMessage && aiInsight.getCorrections() != null) {
+                        saveCorrections(savedReport, aiInsight.getCorrections());
+                    }
 
                     return savedReport;
                 });
 
-        // 3. 최종 DTO 조립 시 필요한 메시지 재조회
-        List<ConversationMessage> messages = messageRepository.findAllBySessionOrderByCreatedAtAsc(session);
-
-        return MyReportResponseDTO.ReportDetailDTO.builder()
-                .reportId(myReport.getId())
-                .sessionSummary(buildSessionSummary(session, myReport))
-                .aiInsightCard(getAiInsightDTO(myReport))
-                .userReflection(myReport.getUserReflection())
-                .conversationLog(buildMessageLogs(messages))
-                .build();
+        return buildReportDetailDTO(myReport, session, messages);
     }
-
+    private void saveCorrections(MyReport report, List<MyReportResponseDTO.CorrectionDTO> correctionDTOs) {
+        List<ConversationCorrection> corrections = correctionDTOs.stream()
+                .map(dto -> ConversationCorrection.builder()
+                        .report(report)
+                        .originalContent(dto.getOriginal())
+                        .correctedContent(dto.getCorrected())
+                        .correctionReason(dto.getReason())
+                        .build())
+                .collect(Collectors.toList());
+        correctionRepository.saveAll(corrections);
+    }
     /**
      * AI 분석 카드 생성 로직
      */
@@ -385,6 +384,21 @@ public class MyReportService {
                         .createdAt(m.getCreatedAt())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private MyReportResponseDTO.ReportDetailDTO buildReportDetailDTO(MyReport myReport, ConversationSession session, List<ConversationMessage> messages) {
+        User user = session.getMyRole().getUser();
+
+        return MyReportResponseDTO.ReportDetailDTO.builder()
+                .reportId(myReport.getId())
+                .sessionSummary(buildSessionSummary(session, myReport))
+                .aiInsightCard(getAiInsightDTO(myReport))
+                .userReflection(myReport.getUserReflection())
+                .conversationLog(buildMessageLogs(messages))
+                .isLogLocked(false)
+                .usedLogViewCount(user.getTotalLogViewCount())
+                .maxLogViewCount(MAX_FREE_VIEW_COUNT)
+                .build();
     }
 
     /**


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> #128 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 사용자 대화 내역이 없더라도 리포트는 생성 가능하도록 변경

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [x] Reviewer에 백엔드 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)
<img width="2804" height="766" alt="image" src="https://github.com/user-attachments/assets/0d9822e3-4717-43ba-9aa3-d9e186b92900" />

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 사용자 메시지가 없어도 기본 AI 요약과 이유로 보고서를 생성합니다(교정 항목은 비어 있음).
  * 보고서 상세에 잠금 상태, 사용한 로그 열람 횟수, 최대 열람 횟수를 표시합니다.
* 버그 수정
  * 사용자 메시지가 없을 때 발생하던 오류로 보고서 생성이 중단되던 문제를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->